### PR TITLE
fix: fix immutable change exception during pdf print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+
+## [4.5.1](https://github.com/aivot-digital/gover/compare/v4.5.0...v4.5.1) (TBD)
+
+### Bug Fixes
+* **PDF-Print:** Fix issue with empty PDF print not resolving disabled or technical fields correctly.
+
 ## [4.5.0](https://github.com/aivot-digital/gover/compare/v4.4.0...v4.5.0) (2025-06-27)
 
 ### Features

--- a/src/main/java/de/aivot/GoverBackend/services/PdfService.java
+++ b/src/main/java/de/aivot/GoverBackend/services/PdfService.java
@@ -99,7 +99,7 @@ public class PdfService {
 
         var derivationContext = formDerivationServiceFactory
                 .create(form, List.of(), List.of(FormDerivationService.FORM_STEP_LIMIT_ALL_IDENTIFIER), List.of(FormDerivationService.FORM_STEP_LIMIT_ALL_IDENTIFIER), List.of(FormDerivationService.FORM_STEP_LIMIT_ALL_IDENTIFIER))
-                .derive(form.getRoot(), Map.of());
+                .derive(form.getRoot(), new HashMap<>());
         try {
             derivationContext.close();
         } catch (Exception e) {


### PR DESCRIPTION
Fix a bug, where pdf prints could not be created, when a technical or disabled field was present in a form. This was a result of changes to the cleaning of input data and an immutable collection passed as input data to the priting process.

CU-86c4k2qw6