### PR TITLE
fix: fix sorting in department memberships lists of users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * **Development:** Fix broken keycloak setup in the development environment
 * **Backend:** Upgrade GraalVM to the newest polyglot version.
 * **PDF-Print:** Fix issue with empty PDF print not resolving disabled or technical fields correctly.
+* **App:** Fix an issue with the sorting in the department memberships list of user profiles.
+* **App:** Fix an issue with the sorting of user memberships in the department details view.
 
 ## [4.5.0](https://github.com/aivot-digital/gover/compare/v4.4.0...v4.5.0) (2025-06-27)
 

--- a/app/src/modules/departments/pages/details/departments-details-page-members.tsx
+++ b/app/src/modules/departments/pages/details/departments-details-page-members.tsx
@@ -245,7 +245,7 @@ export function DepartmentsDetailsPageMembers() {
                         .list(
                             options.page,
                             options.size,
-                            options.sort,
+                            (options.sort as any) === 'enabled' ? 'userEnabled' : options.sort,
                             options.order,
                             filters,
                         );

--- a/app/src/modules/users/pages/account/account-details-page-department-memberships.tsx
+++ b/app/src/modules/users/pages/account/account-details-page-department-memberships.tsx
@@ -3,11 +3,12 @@ import {useSelector} from 'react-redux';
 import {selectUser} from '../../../../slices/user-slice';
 import {DepartmentMembershipsApiService} from '../../../departments/department-memberships-api-service';
 import {UserRole, UserRoleLabels} from '../../../../data/user-role';
-import {EditOutlined} from '@mui/icons-material';
+import EditOutlined from '@mui/icons-material/EditOutlined';
 import {GenericList} from '../../../../components/generic-list/generic-list';
-import {DepartmentMembershipResponseDTO} from '../../../departments/dtos/department-membership-response-dto';
+import {type DepartmentMembershipResponseDTO} from '../../../departments/dtos/department-membership-response-dto';
 import {CellLink} from '../../../../components/cell-link/cell-link';
-import {Box, Typography} from '@mui/material';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
 import {isAdmin} from '../../../../utils/is-admin';
 
 export function AccountDetailsPageDepartmentMemberships() {
@@ -57,7 +58,7 @@ export function AccountDetailsPageDepartmentMemberships() {
                 ]}
                 fetch={(options) => {
                     return new DepartmentMembershipsApiService(options.api)
-                        .listAll({
+                        .listAllOrdered((options.sort === 'departmentName' ? 'name' : 'membershipRole') as any, options.order, {
                             userId: user?.id,
                             departmentName: options.search,
                         });

--- a/app/src/modules/users/pages/user/details/user-details-page-department-memberships.tsx
+++ b/app/src/modules/users/pages/user/details/user-details-page-department-memberships.tsx
@@ -1,13 +1,14 @@
 import React, {useContext} from 'react';
 import {DepartmentMembershipsApiService} from '../../../../departments/department-memberships-api-service';
-import type {GridColDef} from '@mui/x-data-grid';
+import {type GridColDef} from '@mui/x-data-grid';
 import {UserRoleLabels} from '../../../../../data/user-role';
-import {EditOutlined} from '@mui/icons-material';
+import EditOutlined from '@mui/icons-material/EditOutlined';
 import {GenericList} from '../../../../../components/generic-list/generic-list';
 import {CellLink} from '../../../../../components/cell-link/cell-link';
-import {Box, Typography} from '@mui/material';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
 import {type User} from '../../../../../models/entities/user';
-import {DepartmentMembershipResponseDTO} from '../../../../departments/dtos/department-membership-response-dto';
+import {type DepartmentMembershipResponseDTO} from '../../../../departments/dtos/department-membership-response-dto';
 import {GenericDetailsPageContext, GenericDetailsPageContextType} from '../../../../../components/generic-details-page/generic-details-page-context';
 import {GenericDetailsSkeleton} from '../../../../../components/generic-details-page/generic-details-skeleton';
 
@@ -68,7 +69,7 @@ export function UserDetailsPageDepartmentMemberships() {
                 columnDefinitions={columns}
                 fetch={(options) => {
                     return new DepartmentMembershipsApiService(options.api)
-                        .listAll({
+                        .listAllOrdered((options.sort === 'departmentName' ? 'name' : 'membershipRole') as any, options.order, {
                             userId: user?.id,
                             departmentName: options.search,
                         });

--- a/app/src/modules/users/pages/user/details/user-details-page-department-memberships.tsx
+++ b/app/src/modules/users/pages/user/details/user-details-page-department-memberships.tsx
@@ -1,6 +1,4 @@
 import React, {useContext} from 'react';
-import {useApi} from '../../../../../hooks/use-api';
-import {DepartmentMembership} from '../../../../departments/models/department-membership';
 import {DepartmentMembershipsApiService} from '../../../../departments/department-memberships-api-service';
 import type {GridColDef} from '@mui/x-data-grid';
 import {UserRoleLabels} from '../../../../../data/user-role';
@@ -10,10 +8,7 @@ import {CellLink} from '../../../../../components/cell-link/cell-link';
 import {Box, Typography} from '@mui/material';
 import {type User} from '../../../../../models/entities/user';
 import {DepartmentMembershipResponseDTO} from '../../../../departments/dtos/department-membership-response-dto';
-import {
-    GenericDetailsPageContext,
-    GenericDetailsPageContextType,
-} from '../../../../../components/generic-details-page/generic-details-page-context';
+import {GenericDetailsPageContext, GenericDetailsPageContextType} from '../../../../../components/generic-details-page/generic-details-page-context';
 import {GenericDetailsSkeleton} from '../../../../../components/generic-details-page/generic-details-skeleton';
 
 const columns: Array<GridColDef<DepartmentMembershipResponseDTO>> = [


### PR DESCRIPTION
# Description
It was not possible to sort the lists of department memberships in the details pages for a users profile or the admin view of a users profile. It was also not possible to sort by state in the list of members in the details page of a department.

## Known Bugs
Sorting by state in the members list of a department is only possible to sort enabled/disabled. The deleted state is not considered during sort. We need to revisite the way, sorting information is passed from the generic list component to the fetch function in order so resolve this proble, or split the state column into two different colums, one for enabled/disabled and one for deleted/not deleted.