### PR TITLE
chore: set release date in changelog for patch 4.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [4.5.1](https://github.com/aivot-digital/gover/compare/v4.5.0...v4.5.1) (TBD)
+## [4.5.1](https://github.com/aivot-digital/gover/compare/v4.5.0...v4.5.1) (2025-07-22)
 
 ### Bug Fixes
 * **Payment:** Fix issue with missing context object int the payment quantity calculation low code.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,7 +115,7 @@ services:
 
 
   gover:
-    image: ghcr.io/aivot-digital/gover:4.5.0
+    image: ghcr.io/aivot-digital/gover:4.5.1
     depends_on:
       - gover_database
       - clamav
@@ -188,7 +188,7 @@ services:
 
 
   gover_staff_app:
-    image: ghcr.io/aivot-digital/gover:4.5.0
+    image: ghcr.io/aivot-digital/gover:4.5.1
     restart: always
     command: staff
     networks:
@@ -201,7 +201,7 @@ services:
 
 
   gover_customer_app:
-    image: ghcr.io/aivot-digital/gover:4.5.0
+    image: ghcr.io/aivot-digital/gover:4.5.1
     restart: always
     command: customer
     networks:


### PR DESCRIPTION
Set the release date in the changelog for patch 4.5.1