### PR TITLE
feat: new simplified versioning for forms and presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * **App:** Upgrade all frontend dependencies to the latest versions, including React 19, MUI 7 and MUI X 8.
 * **App:** Introduce Vite as the new build tool for the frontend, replacing CRA, to improve the development experience and build performance.
+* **App:** Introduce a simplified versioning mechanism for both forms and presets which sets the new version number automatically.
 * **System:** Decoupled the frontend, backend and oidc-provider by introducing new configuration variables
 * **System:** Added SBOM generation to the build process, providing a Software Bill of Materials for better transparency and security.
 * **System:** Implemented a license compliance check in the build process to ensure all dependencies comply with licensing requirements.

--- a/app/src/components/application-list-item/application-list-item.tsx
+++ b/app/src/components/application-list-item/application-list-item.tsx
@@ -141,7 +141,7 @@ export function ApplicationListItem(props: ApplicationListItemProps): JSX.Elemen
                         variant="caption"
                         sx={{ml: 1}}
                     >
-                        {props.application.version}
+                        Version {props.application.version}
                     </Typography>
                 </Typography>
 

--- a/app/src/dialogs/application-dialogs/add-application-dialog/add-application-dialog.tsx
+++ b/app/src/dialogs/application-dialogs/add-application-dialog/add-application-dialog.tsx
@@ -6,7 +6,6 @@ import {type AddApplicationDialogProps} from './add-application-dialog-props';
 import {TextFieldComponent} from '../../../components/text-field/text-field-component';
 import {slugify} from '../../../utils/slugify';
 import {checkTitle} from '../../../utils/check-title';
-import {checkVersion} from '../../../utils/version-utils';
 import {checkSlugAndVersion} from '../../../utils/check-slug-and-version';
 import {SelectFieldComponent} from '../../../components/select-field/select-field-component';
 import {useAppSelector} from '../../../hooks/use-app-selector';
@@ -15,7 +14,6 @@ import {useApi} from '../../../hooks/use-api';
 import {DepartmentsApiService} from '../../../modules/departments/departments-api-service';
 import {Department} from '../../../modules/departments/models/department';
 import {FormsApiService} from '../../../modules/forms/forms-api-service';
-
 
 type ErrorsType = {
     [key in keyof Application]?: string;
@@ -62,6 +60,14 @@ export function AddApplicationDialog(props: AddApplicationDialogProps): JSX.Elem
                     developingDepartment: 0,
                     id: 0,
                 });
+            } else if (mode === 'new-version' && applicationToBaseOn?.slug) {
+                new FormsApiService(api)
+                    .getNextVersion(applicationToBaseOn.slug)
+                    .then(nextVersion => {
+                        let applicationBase = JSON.parse(JSON.stringify(applicationToBaseOn));
+                        applicationBase.version = nextVersion;
+                        setApplication(applicationBase);
+                    });
             } else {
                 let applicationBase = JSON.parse(JSON.stringify(applicationToBaseOn));
 
@@ -97,20 +103,11 @@ export function AddApplicationDialog(props: AddApplicationDialogProps): JSX.Elem
             errors.title = titleErrors[0];
         }
 
-        const versionErrors = checkVersion(application.version);
-        if (versionErrors.length > 0) {
-            errors.version = versionErrors[0];
-        }
-
         const {
             slugError,
-            versionError,
-        } = checkSlugAndVersion(existingApplications, application.slug, application.version);
+        } = checkSlugAndVersion(existingApplications, application.slug);
         if (slugError != null) {
             errors.slug = slugError;
-        }
-        if (versionError != null) {
-            errors.version = versionError;
         }
 
         if (Object.keys(errors).length > 0) {
@@ -145,7 +142,7 @@ export function AddApplicationDialog(props: AddApplicationDialogProps): JSX.Elem
 
                 {
                     mode === 'new-version' &&
-                    'Neue Version anlegen'
+                    `Neue Version Nr. ${application.version} anlegen`
                 }
 
                 {
@@ -272,26 +269,17 @@ export function AddApplicationDialog(props: AddApplicationDialogProps): JSX.Elem
                         mb: 2,
                     }}
                 >
-                    Vergeben Sie die Version des Formulars. Unter dieser wird das Formular für antragstellende Personen verfügbar
-                    sein. Achten Sie darauf, dass Sie dem Schema der semantischen Versionierung folgen.
-                    Die Version besteht aus drei Zahlen, die jeweils durch einen Punkt getrennt werden. Die erste Zahl
-                    gibt die Hauptversion (Major) an und sollte nur bei tiefgreifenden Änderungen erhöht werden. Die
-                    zweite Zahl gibt die Nebenversion (Minor) an und sollte bei kleineren Änderungen erhöht werden. Die
-                    dritte Zahl gibt die Fehlerkorrekturen (Fix) an und sollte nur bei solchen erhöht werden.
+                    Die Version wird hier nur für das Review angezeigt und wird später entfernt. Bei einer neuen Version wird die Versionsnummer in der Überschrift des Dialogs angezeigt.
                 </Typography>
 
                 <TextFieldComponent
                     label="Version des Formulars"
-                    placeholder="1.0.0"
+                    placeholder="1"
                     value={application.version}
-                    onChange={(val) => {
-                        handlePatch({
-                            version: val,
-                        });
+                    onChange={() => {
                     }}
                     required
-                    error={errors.version}
-                    maxCharacters={11}
+                    disabled
                 />
 
                 <Alert

--- a/app/src/dialogs/preset-dialogs/add-preset-dialog/add-preset-dialog.tsx
+++ b/app/src/dialogs/preset-dialogs/add-preset-dialog/add-preset-dialog.tsx
@@ -40,21 +40,6 @@ function validate(preset: Preset): Errors | null {
         };
     }
 
-    if (preset.currentVersion == null || preset.currentVersion.length < 5 || preset.currentVersion.length > 11) {
-        errors = {
-            ...(errors ?? {}),
-            currentVersion: 'Bitte geben Sie einen Version mit mindestens 5 weniger als 12 Zeichen ein',
-        };
-    }
-
-    const versionRegex = /^[0-9]+(\.[0-9]+){2}$/;
-    if (!versionRegex.test(preset.currentVersion)) {
-        errors = {
-            ...(errors ?? {}),
-            currentVersion: 'Bitte geben Sie eine gültige Version nach dem Schema X.Y.Z ein',
-        };
-    }
-
     return errors;
 }
 
@@ -104,7 +89,7 @@ export function AddPresetDialog(props: AddPresetDialogProps): JSX.Element {
 
                     const createdVersion = await presetVersionsApiService.create({
                         preset: createdPreset.key,
-                        version: preset.currentVersion,
+                        version: '1',
                         root: root ?? generateElementWithDefaultValues(ElementType.Container) as GroupLayout,
                         publishedAt: null,
                         publishedStoreAt: null,
@@ -177,36 +162,6 @@ export function AddPresetDialog(props: AddPresetDialogProps): JSX.Element {
                     error={errors.title}
                     maxCharacters={190}
                     minCharacters={3}
-                />
-
-                <Typography
-                    variant="body2"
-                    sx={{
-                        mt: 4,
-                        mb: 2,
-                    }}
-                >
-                    Vergeben Sie die Version der Vorlage. Unter dieser wird die Vorlage verfügbar
-                    sein. Achten Sie darauf, dass Sie dem Schema der semantischen Versionierung folgen.
-                    Die Version besteht aus drei Zahlen, die jeweils durch einen Punkt getrennt werden. Die erste Zahl
-                    gibt die Hauptversion (Major) an und sollte nur bei tiefgreifenden Änderungen erhöht werden. Die
-                    zweite Zahl gibt die Nebenversion (Minor) an und sollte bei kleineren Änderungen erhöht werden. Die
-                    dritte Zahl gibt die Fehlerkorrekturen (Fix) an und sollte nur bei solchen erhöht werden.
-                </Typography>
-
-                <TextFieldComponent
-                    label="Version der Vorlage"
-                    placeholder="1.0.0"
-                    value={preset.currentVersion}
-                    onChange={(val) => {
-                        handlePatch({
-                            currentVersion: val,
-                        });
-                    }}
-                    required
-                    error={errors.currentVersion}
-                    maxCharacters={11}
-                    minCharacters={5}
                 />
 
                 <Alert

--- a/app/src/modules/forms/forms-api-service.ts
+++ b/app/src/modules/forms/forms-api-service.ts
@@ -63,7 +63,7 @@ export class FormsApiService extends CrudApiService<Form, Form, FormCitizenListR
         return {
             id: 0,
             slug: '',
-            version: '',
+            version: '1',
             title: '',
             status: ApplicationStatus.Drafted,
             type: FormType.Public,
@@ -206,4 +206,9 @@ export class FormsApiService extends CrudApiService<Form, Form, FormCitizenListR
     public checkPublish(id: number): Promise<FormPublishChecklistItem[]> {
         return this.api.get<FormPublishChecklistItem[]>(`forms/${id}/check-publish/`);
     }
+
+    public getNextVersion(slug: string): Promise<string> {
+        return this.api.get(`forms/next-version/${slug}`);
+    }
+
 }

--- a/app/src/modules/presets/preset-version-api-service.ts
+++ b/app/src/modules/presets/preset-version-api-service.ts
@@ -29,4 +29,8 @@ export class PresetVersionApiService extends CrudApiService<
             updated: new Date().toISOString(),
         };
     }
+
+    async getNextVersion(presetKey: string): Promise<string> {
+        return await this.api.get(`presets/${presetKey}/versions/next-version/`);
+    }
 }

--- a/app/src/pages/staff-pages/application-pages/form-edit-page.tsx
+++ b/app/src/pages/staff-pages/application-pages/form-edit-page.tsx
@@ -436,10 +436,10 @@ export function FormEditPage() {
         return (
             <ThemeProvider theme={_theme}>
                 <MetaElement
-                    title={`Editor - ${loadedForm.title} - ${loadedForm.version}`}
+                    title={`Editor - ${loadedForm.title} - Version ${loadedForm.version}`}
                 />
                 <AppToolbar
-                    title={`${loadedForm.title} - ${loadedForm.version}`}
+                    title={`${loadedForm.title} - Version ${loadedForm.version}`}
                     updateToolbarHeight={updateToolbarHeight}
                     actions={[
                         {

--- a/app/src/pages/staff-pages/preset-pages/preset-edit-page.tsx
+++ b/app/src/pages/staff-pages/preset-pages/preset-edit-page.tsx
@@ -26,18 +26,18 @@ import {ElementType} from '../../../data/element-type/element-type';
 import {GroupLayout} from '../../../models/elements/form/layout/group-layout';
 import {PresetsApiService} from '../../../modules/presets/presets-api-service';
 import {PresetVersionApiService} from '../../../modules/presets/preset-version-api-service';
-import {usePrompt} from '../../../providers/prompt-provider';
 import {CustomerInput} from '../../../models/customer-input';
 import {hideLoadingOverlay, showLoadingOverlay} from '../../../slices/loading-overlay-slice';
 import {withAsyncWrapper} from '../../../utils/with-async-wrapper';
 import {FormState} from '../../../models/dtos/form-state';
 import {IdentityProviderInfo} from '../../../modules/identity/models/identity-provider-info';
 import {IdentityProvidersApiService} from '../../../modules/identity/identity-providers-api-service';
+import {useConfirm} from '../../../providers/confirm-provider';
 
 export function PresetEditPage(): JSX.Element {
     const api = useApi();
     const dispatch = useAppDispatch();
-    const showPrompt = usePrompt();
+    const showConfirm = useConfirm();
 
     const [isBusy, setIsBusy] = useState(false);
     const [isDeriving, setIsDeriving] = useState(false);
@@ -170,24 +170,36 @@ export function PresetEditPage(): JSX.Element {
     };
 
     const handleAddNewVersion = async () => {
-        if (!preset) return;
+        if (!preset || !preset.key) return;
 
-        const newVersion = await showPrompt({
+        const presetVersionApiService = new PresetVersionApiService(api, preset.key);
+
+        let nextVersion: string;
+        try {
+            nextVersion = await presetVersionApiService.getNextVersion(preset.key);
+        } catch (error) {
+            dispatch(showErrorSnackbar('Nächste Version konnte nicht bestimmt werden.'));
+            console.error(error);
+            return;
+        }
+
+        const createNewVersionPrompt = await showConfirm({
             title: 'Neue Version anlegen',
-            message: 'Bitte geben Sie eine Versionsnummer für die neue Vorlagen-Version ein:',
-            inputLabel: 'Versionsnummer',
-            inputPlaceholder: versionNumber ?? '1.0.0',
-            confirmButtonText: 'Erstellen',
-            cancelButtonText: 'Abbrechen',
-            defaultValue: versionNumber ?? '1.0.0',
+            confirmButtonText: "Ja, Version anlegen",
+            children: (
+                <>
+                    <div>
+                        Möchten Sie wirklich eine neue Version Nr. {nextVersion} der Vorlage "{preset.title}" anlegen?
+                    </div>
+                </>
+            )
         });
 
-        if (!newVersion) return;
-        const presetVersionApiService = new PresetVersionApiService(api, preset.key);
+        if (!createNewVersionPrompt) return;
 
         const newPresetVersion: PresetVersion = {
             preset: preset.key,
-            version: newVersion,
+            version: nextVersion,
             root: presetVersion ? presetVersion.root : generateElementWithDefaultValues(ElementType.Container) as GroupLayout,
             publishedAt: null,
             publishedStoreAt: null,
@@ -369,10 +381,10 @@ export function PresetEditPage(): JSX.Element {
     return (
         <>
             <MetaElement
-                title={`Vorlagen-Editor - ${preset.title} - ${versionNumber ?? ''} (${determinePresetVersionDescriptor(preset, presetVersion)})`}
+                title={`Vorlagen-Editor - ${preset.title} - Version ${versionNumber ?? ''} (${determinePresetVersionDescriptor(preset, presetVersion)})`}
             />
             <AppToolbar
-                title={`${preset.title} - ${versionNumber ?? ''} (${determinePresetVersionDescriptor(preset, presetVersion)})`}
+                title={`${preset.title} - Version ${versionNumber ?? ''} (${determinePresetVersionDescriptor(preset, presetVersion)})`}
                 updateToolbarHeight={updateToolbarHeight}
                 actions={[
                     {

--- a/app/src/utils/check-slug-and-version.ts
+++ b/app/src/utils/check-slug-and-version.ts
@@ -2,11 +2,9 @@ import {type Form as Application, FormListProjection} from '../models/entities/f
 
 export function checkSlugAndVersion(applications: Application[] | FormListProjection[], slug?: string, version?: string): {
     slugError?: string;
-    versionError?: string;
 } {
     const errors: {
         slugError?: string;
-        versionError?: string;
     } = {};
 
     const trimmedSlug = slug?.trim() ?? '';
@@ -26,7 +24,6 @@ export function checkSlugAndVersion(applications: Application[] | FormListProjec
 
     if (applications != null && applications?.some((app) => app.slug === trimmedSlug && app.version === trimmedVersion)) {
         errors.slugError = 'Es existiert bereits ein Formular mit diesem URL-Element und dieser Version.';
-        errors.versionError = 'Es existiert bereits ein Formular mit diesem URL-Element und dieser Version.';
     }
 
     return errors;

--- a/app/src/utils/version-utils.ts
+++ b/app/src/utils/version-utils.ts
@@ -20,39 +20,26 @@ export function checkVersion(version?: string): string[] {
 }
 
 export function compareVersions(versionA: string, versionB: string): number {
-    const vAParts = versionA.split('.').map(v => parseInt(v));
-    const vBParts = versionB.split('.').map(v => parseInt(v));
+    const parseVersion = (v: string): number[] => {
+        return v
+            .split('.')
+            .map(part => parseInt(part, 10))
+            .filter(n => !isNaN(n));
+    };
 
-    if (vAParts.length !== 3) {
-        return 1;
-    }
-    if (vBParts.length !== 3) {
-        return -1;
-    }
+    const vA = parseVersion(versionA);
+    const vB = parseVersion(versionB);
 
-    const [majorA, minorA, patchA] = vAParts;
-    const [majorB, minorB, patchB] = vBParts;
+    const maxLength = Math.max(vA.length, vB.length);
 
-    if (majorA < majorB) {
-        return 1;
-    }
-    if (majorA > majorB) {
-        return -1;
-    }
+    for (let i = 0; i < maxLength; i++) {
+        const a = vA[i] ?? 0;
+        const b = vB[i] ?? 0;
 
-    if (minorA < minorB) {
-        return 1;
-    }
-    if (minorA > minorB) {
-        return -1;
-    }
-
-    if (patchA < patchB) {
-        return 1;
-    }
-    if (patchA > patchB) {
-        return -1;
+        if (a < b) return 1;
+        if (a > b) return -1;
     }
 
     return 0;
 }
+

--- a/src/main/java/de/aivot/GoverBackend/form/controllers/FormController.java
+++ b/src/main/java/de/aivot/GoverBackend/form/controllers/FormController.java
@@ -29,6 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
@@ -503,6 +504,18 @@ public class FormController {
             exceptionMailService.send(e);
         }
     }
+
+    /**
+     * Get the next version of a form by its slug.
+     *
+     * @param slug The slug of the form.
+     * @return The next version of the form as a string.
+     */
+    @GetMapping("/next-version/{slug}")
+    public ResponseEntity<String> getNextVersion(@PathVariable String slug) {
+        return ResponseEntity.ok(formService.getNextVersion(slug));
+    }
+
 
     /**
      * Check if a form is locked by another user.

--- a/src/main/java/de/aivot/GoverBackend/form/dtos/FormRequestDTO.java
+++ b/src/main/java/de/aivot/GoverBackend/form/dtos/FormRequestDTO.java
@@ -30,7 +30,7 @@ public record FormRequestDTO(
 
         @NotNull(message = "version cannot be null")
         @NotBlank(message = "version cannot be blank")
-        @Length(min = 5, max = 11, message = "version must be at least 5 character long")
+        @Length(min = 1, max = 11, message = "version must be at least 1 character long")
         String version,
 
         @NotNull(message = "title cannot be null")

--- a/src/main/java/de/aivot/GoverBackend/form/repositories/FormRepository.java
+++ b/src/main/java/de/aivot/GoverBackend/form/repositories/FormRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.util.Collection;
 import java.util.Optional;
+import java.util.List;
 
 public interface FormRepository extends JpaRepository<Form, Integer>, JpaSpecificationExecutor<Form> {
     @Query(value = """
@@ -33,4 +34,7 @@ public interface FormRepository extends JpaRepository<Form, Integer>, JpaSpecifi
             );
             """, nativeQuery = true)
     boolean existsWithLinkedIdentityProvider(String identityProviderKey);
+
+    List<Form> findBySlug(String slug);
+
 }

--- a/src/main/java/de/aivot/GoverBackend/form/services/FormService.java
+++ b/src/main/java/de/aivot/GoverBackend/form/services/FormService.java
@@ -32,9 +32,7 @@ import org.springframework.stereotype.Service;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @Service
 public class FormService implements EntityService<Form, Integer> {
@@ -87,6 +85,8 @@ public class FormService implements EntityService<Form, Integer> {
         if (repository.existsBySlugAndVersion(entity.getSlug(), entity.getVersion())) {
             throw new ResponseException(HttpStatus.CONFLICT, "Es existiert bereits ein Formular mit dieser URL und dieser Version");
         }
+
+        validateVersionIsNext(entity.getSlug(), entity.getVersion());
 
         var cleanedEntity = cleanRelatedData(entity);
 
@@ -431,4 +431,51 @@ public class FormService implements EntityService<Form, Integer> {
         existingForm.setStatus(FormStatus.Revoked);
         return repository.save(existingForm);
     }
+
+    @Nonnull
+    public String getNextVersion(String slug) {
+        List<Form> forms = repository.findBySlug(slug);
+
+        int max = forms.stream()
+                .map(Form::getVersion)
+                .filter(Objects::nonNull)
+                .map(FormService::extractMajorVersion)
+                .filter(OptionalInt::isPresent)
+                .mapToInt(OptionalInt::getAsInt)
+                .max()
+                .orElse(0);
+
+        return String.valueOf(max + 1);
+    }
+
+    private static OptionalInt extractMajorVersion(String version) {
+        try {
+            if (version.matches("^\\d+$")) {
+                return OptionalInt.of(Integer.parseInt(version));
+            } else if (version.matches("^\\d+\\.\\d+(\\.\\d+)?$")) {
+                String major = version.split("\\.")[0];
+                return OptionalInt.of(Integer.parseInt(major));
+            } else {
+                return OptionalInt.empty();
+            }
+        } catch (NumberFormatException e) {
+            return OptionalInt.empty();
+        }
+    }
+
+
+    public void validateVersionIsNext(String slug, String version) throws ResponseException {
+        if (!version.matches("\\d+")) {
+            throw new ResponseException(HttpStatus.CONFLICT, "Neue Versionen müssen ganze Zahlen sein (z. B. 1, 2, 3).");
+        }
+
+        int submitted = Integer.parseInt(version);
+        String next = getNextVersion(slug);
+        int expected = Integer.parseInt(next);
+
+        if (submitted != expected) {
+            throw new ResponseException(HttpStatus.CONFLICT, "Ungültige Version. Erwartet wurde Version " + expected + ".");
+        }
+    }
+
 }

--- a/src/main/java/de/aivot/GoverBackend/preset/controllers/PresetVersionController.java
+++ b/src/main/java/de/aivot/GoverBackend/preset/controllers/PresetVersionController.java
@@ -14,13 +14,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.OptionalInt;
+
+import static java.lang.Integer.parseInt;
 
 @RestController
 @RequestMapping("/api/presets/{presetKey}/versions/")
@@ -97,6 +103,8 @@ public class PresetVersionController {
         if (exists) {
             throw ResponseException.conflict("Diese Vorlagen-Version existiert bereits.");
         }
+
+        validateVersionIsNext(newVersion.getPreset(), newVersion.getVersion());
 
         var savedVersion = versionRepository.save(newVersion);
 
@@ -253,4 +261,52 @@ public class PresetVersionController {
                 )
         );
     }
+
+    @GetMapping("next-version/")
+    public ResponseEntity<String> getNextVersion(@Nonnull @PathVariable String presetKey) {
+        String nextVersion = getNextVersionNumber(presetKey);
+        return ResponseEntity.ok(nextVersion);
+    }
+
+    public String getNextVersionNumber(String presetKey) {
+        List<PresetVersion> versions = versionRepository.findByPreset(presetKey);
+
+        int max = versions.stream()
+                .map(PresetVersion::getVersion)
+                .filter(Objects::nonNull)
+                .map(PresetVersionController::extractMajorVersion)
+                .filter(OptionalInt::isPresent)
+                .mapToInt(OptionalInt::getAsInt)
+                .max()
+                .orElse(0);
+
+        return String.valueOf(max + 1);
+    }
+
+    private static OptionalInt extractMajorVersion(String version) {
+        try {
+            if (version.matches("^\\d+$")) {
+                return OptionalInt.of(parseInt(version));
+            } else if (version.matches("^\\d+\\.\\d+(\\.\\d+)?$")) {
+                return OptionalInt.of(parseInt(version.split("\\.")[0]));
+            }
+        } catch (NumberFormatException e) {
+            return OptionalInt.empty();
+        }
+        return OptionalInt.empty();
+    }
+
+    public void validateVersionIsNext(String presetKey, String submittedVersion) {
+        if (!submittedVersion.matches("^\\d+$")) {
+            throw new IllegalArgumentException("Neue Versionen müssen ganze Zahlen sein (z. B. 1, 2, 3).");
+        }
+
+        int submitted = parseInt(submittedVersion);
+        int expected = parseInt(getNextVersionNumber(presetKey));
+
+        if (submitted != expected) {
+            throw new IllegalArgumentException("Ungültige Version. Erwartet wurde Version " + expected + ".");
+        }
+    }
+
 }

--- a/src/main/java/de/aivot/GoverBackend/preset/repositories/PresetVersionRepository.java
+++ b/src/main/java/de/aivot/GoverBackend/preset/repositories/PresetVersionRepository.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.Pageable;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface PresetVersionRepository extends JpaRepository<PresetVersion, String> {
@@ -19,9 +20,9 @@ public interface PresetVersionRepository extends JpaRepository<PresetVersion, St
     @Query("SELECT v FROM PresetVersion v WHERE v.preset = ?1 ORDER BY string_to_array(v.version, '.') DESC")
     Page<PresetVersion> findAllByPreset(String preset, Pageable pageable);
 
-    
     boolean existsByPresetAndVersion(String preset, String version);
 
-    
     boolean existsByPreset(String preset);
+
+    List<PresetVersion> findByPreset(String presetKey);
 }


### PR DESCRIPTION
This pull request introduces a simplified versioning mechanism for both forms and presets. Instead of relying on manually entered semantic versions (1.0.0, 1.2.3, etc.), new versions are now automatically assigned using incremental whole numbers (1, 2, 3, ...). This applies when creating a new form version or a new preset version.

Legacy semantic versions remain fully supported and are preserved as-is.