### PR TITLE
fix: fix error in preset derivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [4.5.1](https://github.com/aivot-digital/gover/compare/v4.5.1...v4.5.2) (TBD)
+
+### Bug Fixes
+* **Backend:** Fix issue with broken preset derivation in the backend.
+
 ## [4.5.1](https://github.com/aivot-digital/gover/compare/v4.5.0...v4.5.1) (2025-07-22)
 
 ### Bug Fixes

--- a/src/main/java/de/aivot/GoverBackend/form/services/FormDerivationService.java
+++ b/src/main/java/de/aivot/GoverBackend/form/services/FormDerivationService.java
@@ -68,9 +68,17 @@ public class FormDerivationService extends BaseElementDerivationService<FormDeri
     ) {
         deriveElement(context, rootElement, deriveVisibilities, deriveOverrides, deriveValues, deriveErrors, null, true);
 
-        deriveIntroductionStepElement(context, rootElement.getIntroductionStep(), deriveVisibilities, deriveOverrides, deriveValues, deriveErrors);
-        deriveSummaryStepElement(context, rootElement.getSummaryStep(), deriveVisibilities, deriveOverrides, deriveValues, deriveErrors);
-        deriveSubmitStepElement(context, rootElement.getSubmitStep(), deriveVisibilities, deriveOverrides, deriveValues, deriveErrors);
+        if (rootElement.getIntroductionStep() != null) {
+            deriveIntroductionStepElement(context, rootElement.getIntroductionStep(), deriveVisibilities, deriveOverrides, deriveValues, deriveErrors);
+        }
+
+        if (rootElement.getSummaryStep() != null) {
+            deriveSummaryStepElement(context, rootElement.getSummaryStep(), deriveVisibilities, deriveOverrides, deriveValues, deriveErrors);
+        }
+
+        if (rootElement.getSubmitStep() != null) {
+            deriveSubmitStepElement(context, rootElement.getSubmitStep(), deriveVisibilities, deriveOverrides, deriveValues, deriveErrors);
+        }
 
         for (var step : rootElement.getChildren()) {
             deriveStepElement(context, step, deriveVisibilities, deriveOverrides, deriveValues, deriveErrors);


### PR DESCRIPTION
# Description
This change resolves a bug in the preset derivation process that was causing a `NullPointerException` and preventing users from testing presets.

# Cause
The `FormDerivationService` requires a root element to function, but presets only provide a group layout. To work around this, a partial root element was being created. However, the service was attempting to access child elements (`introduction`, `summary`, `submit`) within this partial root, which were null.

This pull request adds the necessary null checks to prevent the `NullPointerException` and ensures the derivation process can proceed correctly with the provided preset data.

CU-86c4p8e9b