### PR TITLE
fix: fix missing data in replicating list summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [4.5.3](https://github.com/aivot-digital/gover/compare/v4.5.2...v4.5.3) (TBD)
+
+### Bug Fixes
+* **App:** Fix missing data from group containers in replicating lists in the summary view.
+
 ## [4.5.2](https://github.com/aivot-digital/gover/compare/v4.5.1...v4.5.2) (2025-07-24)
 
 ### Bug Fixes

--- a/app/src/summaries/group-summary.tsx
+++ b/app/src/summaries/group-summary.tsx
@@ -14,6 +14,8 @@ export function GroupSummary(props: BaseSummaryProps<GroupLayout, void>) {
                         showTechnical={props.showTechnical}
                         allowStepNavigation={props.allowStepNavigation}
                         isBusy={props.isBusy}
+                        idPrefix={props.idPrefix}
+                        customerInput={props.customerInput}
                     />
                 ))
             }


### PR DESCRIPTION
# Description
When placing groups in replicating lists, their content was not shown in the summary.
This was caused by a missing id prefix propagation in the group-summary.tsx component.
Adding the missing propagation fixed the problem.