### PR TITLE
fix: fix cached data showing up in the submission summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [4.5.3](https://github.com/aivot-digital/gover/compare/v4.5.2...v4.5.3) (TBD)
+
+### Bug Fixes
+* **App:** Fix missing data from group containers in replicating lists in the summary view.
+
 ## [4.5.2](https://github.com/aivot-digital/gover/compare/v4.5.1...v4.5.2) (2025-07-24)
 
 ### Bug Fixes

--- a/app/src/components/replicating-container/replication-container.summary.tsx
+++ b/app/src/components/replicating-container/replication-container.summary.tsx
@@ -133,6 +133,7 @@ export function ReplicationContainerSummary(props: BaseSummaryProps<ReplicatingC
                                     showTechnical={props.showTechnical}
                                     customerInput={props.customerInput}
                                     isBusy={props.isBusy}
+                                    allowStepNavigation={props.allowStepNavigation}
                                 />
                             ))
                         }

--- a/app/src/components/step/step.component.summary.tsx
+++ b/app/src/components/step/step.component.summary.tsx
@@ -11,7 +11,7 @@ import {BaseSummaryProps} from '../../summaries/base-summary';
 import EditNoteOutlinedIcon from '@mui/icons-material/EditNoteOutlined';
 import {SummaryDispatcherComponent} from '../summary-dispatcher.component';
 
-export function StepComponentSummary({allElements, model, showTechnical, allowStepNavigation, isBusy}: BaseSummaryProps<StepElement, any>) {
+export function StepComponentSummary({allElements, model, showTechnical, allowStepNavigation, isBusy, idPrefix, customerInput}: BaseSummaryProps<StepElement, any>) {
     const dispatch = useAppDispatch();
     const application = useAppSelector(selectLoadedForm);
 
@@ -83,6 +83,8 @@ export function StepComponentSummary({allElements, model, showTechnical, allowSt
                         showTechnical={showTechnical}
                         allowStepNavigation={allowStepNavigation}
                         isBusy={isBusy}
+                        idPrefix={idPrefix}
+                        customerInput={customerInput}
                     />
                 ))
             }

--- a/app/src/pages/staff-pages/submission-pages/submission-edit-page.tsx
+++ b/app/src/pages/staff-pages/submission-pages/submission-edit-page.tsx
@@ -30,6 +30,7 @@ import CreditCardOffOutlinedIcon from '@mui/icons-material/CreditCardOffOutlined
 import {ConfirmDialogV2} from '../../../dialogs/confirm-dialog/confirm-dialog-v2';
 import {ConfirmDialogOptions} from '../../../hooks/use-confirm-dialog';
 import {isApiError} from '../../../models/api-error';
+import {clearLoadedForm} from '../../../slices/app-slice';
 
 export function SubmissionEditPage() {
     const api = useApi();
@@ -59,6 +60,10 @@ export function SubmissionEditPage() {
     const [isNotFound, setIsNotFound] = useState(false);
 
     const [currentTab, setCurrentTab] = useState(0);
+
+    useEffect(() => {
+        dispatch(clearLoadedForm());
+    }, []);
 
     useEffect(() => {
         if (id != null && api != null) {

--- a/app/src/summaries/group-summary.tsx
+++ b/app/src/summaries/group-summary.tsx
@@ -14,6 +14,8 @@ export function GroupSummary(props: BaseSummaryProps<GroupLayout, void>) {
                         showTechnical={props.showTechnical}
                         allowStepNavigation={props.allowStepNavigation}
                         isBusy={props.isBusy}
+                        idPrefix={props.idPrefix}
+                        customerInput={props.customerInput}
                     />
                 ))
             }


### PR DESCRIPTION
# Description
Cached data showed up in the submission summary.
This might be caused by either the app state not being cleared when loading the submission details, or the customer input not being correctly passed in the layout summary components.
I've added the customer input passing to the respective summary components and added a clearing of the form state to the submission details main view.