### PR TITLE
fix: improve NGINX conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [4.5.4](https://github.com/aivot-digital/gover/compare/v4.5.3...v4.5.4) (2025-XX-XX)
+
+### Bug Fixes
+* **Server:** Disable NGINX server tokens to prevent version disclosure.
+* **Server:** Consolidate Cache Control headers in NGINX configuration to avoid problems with caching proxies.
+
 ## [4.5.3](https://github.com/aivot-digital/gover/compare/v4.5.2...v4.5.3) (2025-08-16)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [4.5.4](https://github.com/aivot-digital/gover/compare/v4.5.3...v4.5.4) (2025-XX-XX)
+## [4.5.4](https://github.com/aivot-digital/gover/compare/v4.5.3...v4.5.4) (2025-09-XX)
 
 ### Bug Fixes
 * **Server:** Disable NGINX server tokens to prevent version disclosure.

--- a/docker/nginx.customer.conf
+++ b/docker/nginx.customer.conf
@@ -2,6 +2,7 @@ server {
     listen      80;
     listen      [::]:80;
     server_name default_server;
+    server_tokens off;
 
     root  /var/www/customer/html;
     index index.html;

--- a/docker/nginx.customer.conf
+++ b/docker/nginx.customer.conf
@@ -12,7 +12,8 @@ server {
 
     location / {
         try_files  $uri /index.html;
-        expires    -1;
-        add_header Cache-Control "no-store, no-cache, must-revalidate";
+        expires off;
+        add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+        add_header Expires "0" always;
     }
 }

--- a/docker/nginx.staff.conf
+++ b/docker/nginx.staff.conf
@@ -2,6 +2,7 @@ server {
     listen      80;
     listen      [::]:80;
     server_name default_server;
+    server_tokens off;
 
     root  /var/www/staff/html;
     index index.html;

--- a/docker/nginx.staff.conf
+++ b/docker/nginx.staff.conf
@@ -16,8 +16,9 @@ server {
     }
 
     location /index.html {
-        expires    -1;
-        add_header Cache-Control "no-store, no-cache, must-revalidate";
+        expires off;
+        add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+        add_header Expires "0" always;
         internal; # This is important to allow the internal redirect to work
     }
 }


### PR DESCRIPTION
Includes two fixes. One to disable NGINX server tokens, so systems do not leak version and system info in Server response header, and another to consolidate our Cache Control headers to prevent duplicate headers, which could lead to problems on older clients. 