### PR TITLE
fix/startup-locking-api-keycloak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [4.5.4](https://github.com/aivot-digital/gover/compare/v4.5.3...v4.5.4) (2025-09-XX)
 
+### Features
+* **Server:** Add uptime check for IDP and API to container entrypoint.
+
 ### Bug Fixes
 * **Server:** Disable NGINX server tokens to prevent version disclosure.
 * **Server:** Consolidate Cache Control headers in NGINX configuration to avoid problems with caching proxies.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,27 +1,38 @@
 #!/bin/sh
 
-if [ $# -eq 0 ]
-  then
-    echo "Missing command! Options are serve, staff, customer"
-    exit 1
+if [ $# -eq 0 ]; then
+  echo "Missing command! Options are serve, staff, customer"
+  exit 1
 fi
 
-if [ "$1" = "serve" ]
-  then
-    echo "Starting server…"
-    java -jar /app/gover.jar
+if [ "$1" = "serve" ]; then
+  echo "Waiting for IDP to be available at ${GOVER_HOSTNAME}/idp/realms/staff…"
+  until curl --output /dev/null --silent --head --fail "${GOVER_HOSTNAME}/idp/realms/staff/"; do
+    sleep 5
+  done
+
+  echo "Starting server…"
+  java -jar /app/gover.jar
 fi
 
-if [ "$1" = "staff" ]
-  then
-    echo "Starting staff…"
-    ln -sf /etc/nginx/sites-available/staff.conf /etc/nginx/sites-enabled/staff.conf
-    nginx
+if [ "$1" = "staff" ]; then
+  echo "Waiting for the API to be available at ${GOVER_HOSTNAME}/api/public/actuator/health…"
+  until curl --output /dev/null --silent --head --fail "${GOVER_HOSTNAME}/api/public/actuator/health"; do
+    sleep 5
+  done
+
+  echo "Starting staff…"
+  ln -sf /etc/nginx/sites-available/staff.conf /etc/nginx/sites-enabled/staff.conf
+  nginx
 fi
 
-if [ "$1" = "customer" ]
-  then
-    echo "Starting customer…"
-    ln -sf /etc/nginx/sites-available/customer.conf /etc/nginx/sites-enabled/customer.conf
-    nginx
+if [ "$1" = "customer" ]; then
+  echo "Waiting for the API to be available at ${GOVER_HOSTNAME}/api/public/actuator/health…"
+  until curl --output /dev/null --silent --head --fail "${GOVER_HOSTNAME}/api/public/actuator/health"; do
+    sleep 5
+  done
+
+  echo "Starting customer…"
+  ln -sf /etc/nginx/sites-available/customer.conf /etc/nginx/sites-enabled/customer.conf
+  nginx
 fi


### PR DESCRIPTION
# Description
When starting the Gover container setup, a locking state can be reached when gover cannot connect to the IDP.
This locking state is preventable by waiting for the IDP to come online.