### PR TITLE
chore: bump version of gover to 4.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [4.5.4](https://github.com/aivot-digital/gover/compare/v4.5.3...v4.5.4) (2025-09-XX)
+## [4.5.4](https://github.com/aivot-digital/gover/compare/v4.5.3...v4.5.4) (2025-11-13)
 
 ### Features
 * **Server:** Add uptime check for IDP and API to container entrypoint.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,7 +115,7 @@ services:
 
 
   gover:
-    image: ghcr.io/aivot-digital/gover:4.5.3
+    image: ghcr.io/aivot-digital/gover:4.5.4
     depends_on:
       - gover_database
       - clamav
@@ -188,7 +188,7 @@ services:
 
 
   gover_staff_app:
-    image: ghcr.io/aivot-digital/gover:4.5.3
+    image: ghcr.io/aivot-digital/gover:4.5.4
     restart: always
     command: staff
     networks:
@@ -201,7 +201,7 @@ services:
 
 
   gover_customer_app:
-    image: ghcr.io/aivot-digital/gover:4.5.3
+    image: ghcr.io/aivot-digital/gover:4.5.4
     restart: always
     command: customer
     networks:


### PR DESCRIPTION
Prepare release 4.5.4