### PR TITLE
feat: differentiate between release and next branch in build config

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -84,7 +84,7 @@ jobs:
         id: build_version
         run: |
           if ${{ github.event_name == 'pull_request' }}; then
-          if [[ "${{ github.event.pull_request.base.ref }}" == "main" || "${{ github.event.pull_request.base.ref }}" == "next" ]]; then
+            if [[ "${{ github.event.pull_request.base.ref }}" == "main" || "${{ github.event.pull_request.base.ref }}" == "next" ]]; then
               SOURCE_BRANCH=${{ github.event.pull_request.head.ref }}
               echo "value=${SOURCE_BRANCH##*/}-beta-${PR_NUMBER}" >> "$GITHUB_OUTPUT"
             else
@@ -92,7 +92,11 @@ jobs:
               echo "value=${TARGET_BRANCH##*/}-alpha-${PR_NUMBER}" >> "$GITHUB_OUTPUT"
             fi
           else
-            echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+            if ${{ github.base_ref == 'next' }}; then
+              echo "value=${GITHUB_RUN_NUMBER#v.next}" >> "$GITHUB_OUTPUT"
+            else
+              echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
       - name: Determine package name and set image name

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -22,7 +22,8 @@ env:
   PR_NUMBER: ${{ github.event.pull_request.number }}
   IS_BETA_RELEASE: ${{ github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'next') }}
   IS_ALPHA_RELEASE: ${{ github.event_name == 'pull_request' && !(github.base_ref == 'main' || github.base_ref == 'next') }}
-  IS_RELEASE: ${{ github.event_name == 'push' }}
+  IS_RELEASE: ${{ github.event_name == 'push' && github.base_ref == 'main' }}
+  IS_NEXT: ${{ github.event_name == 'push' && github.base_ref == 'next' }}
 
 jobs:
   testBackend:

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -93,7 +93,7 @@ jobs:
             fi
           else
             if ${{ github.base_ref == 'next' }}; then
-              echo "value=${GITHUB_RUN_NUMBER#next}" >> "$GITHUB_OUTPUT"
+              echo "value=${GITHUB_RUN_NUMBER#n}" >> "$GITHUB_OUTPUT"
             else
               echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
             fi

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -93,7 +93,7 @@ jobs:
             fi
           else
             if ${{ github.base_ref == 'next' }}; then
-              echo "value=${GITHUB_RUN_NUMBER#v.next}" >> "$GITHUB_OUTPUT"
+              echo "value=${GITHUB_RUN_NUMBER#next}" >> "$GITHUB_OUTPUT"
             else
               echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
             fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * **System:** Reworked form versioning system for ease of use.
 * **System:** Added data object management to the backend and app.
 * **Build-System:** Pre-Release builds are now published to a separate 'gover-next' package.
+* **Build-System:** Create separate workflow to build "next" images.
 
 ## [4.5.4](https://github.com/aivot-digital/gover/compare/v4.5.3...v4.5.4) (2025-09-XX)
 


### PR DESCRIPTION
Update the build workflow to support separate next builds which are tagged with n1.0.0.

With this change we will get images called gover-next:1.0.0 when tagging with n1.0.0.