### PR TITLE
fix: remove broken url check from destination edit page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [4.5.5](https://github.com/aivot-digital/gover/compare/v4.5.4...v4.5.5) (2026-01-29)
+
+### Bug Fixes
+* **App:** Fix issue with restricted url patterns for destinations.
+
+
 ## [4.5.4](https://github.com/aivot-digital/gover/compare/v4.5.3...v4.5.4) (2025-11-13)
 
 ### Features

--- a/app/src/modules/destination/pages/details/destination-details-page-index.tsx
+++ b/app/src/modules/destination/pages/details/destination-details-page-index.tsx
@@ -82,10 +82,10 @@ export const DestinationSchema = yup.object({
             then: (schema) => schema
                 .trim()
                 .max(255, "Die API-Adresse darf maximal 255 Zeichen lang sein.")
-                .matches(
-                    /^https?:\/\/[\w.-]+(:\d+)?(\/[\w./-]*)?$/,
-                    "Bitte eine gültige API-URL eingeben (z. B. https://example.com/api)."
-                )
+                //.matches(
+                //    /^https?:\/\/[\w.-]+(:\d+)?(\/[\w./-]*)?$/,
+                //    "Bitte eine gültige API-URL eingeben (z. B. https://example.com/api)."
+                //)
                 .required("Die API-Adresse ist erforderlich."),
             otherwise: (schema) => schema.notRequired().nullable(),
         }),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,7 +115,7 @@ services:
 
 
   gover:
-    image: ghcr.io/aivot-digital/gover:4.5.4
+    image: ghcr.io/aivot-digital/gover:4.5.5
     depends_on:
       - gover_database
       - clamav
@@ -188,7 +188,7 @@ services:
 
 
   gover_staff_app:
-    image: ghcr.io/aivot-digital/gover:4.5.4
+    image: ghcr.io/aivot-digital/gover:4.5.5
     restart: always
     command: staff
     networks:
@@ -201,7 +201,7 @@ services:
 
 
   gover_customer_app:
-    image: ghcr.io/aivot-digital/gover:4.5.4
+    image: ghcr.io/aivot-digital/gover:4.5.5
     restart: always
     command: customer
     networks:


### PR DESCRIPTION
# Description
You are unable to add destination urls with query params. This fix removes the broken url matching.