### PR TITLE
feat: add option to disable confetti animation after submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 * **App:** Add a new destination type for OZG-Cloud.
+* **App:** Add a new flag to toggle the confetti effect on form submission.
 
 ### Improvements
 

--- a/app/src/components/submit/submit.component.editor.tsx
+++ b/app/src/components/submit/submit.component.editor.tsx
@@ -5,6 +5,7 @@ import {type Form as Application} from '../../models/entities/form';
 import {TextFieldComponent} from '../text-field/text-field-component';
 import {StringListInput} from '../string-list-input/string-list-input';
 import {RichTextEditorComponentView} from "../richt-text-editor/rich-text-editor.component.view";
+import {CheckboxFieldComponent} from '../checkbox-field/checkbox-field-component';
 
 export function SubmitComponentEditor(props: BaseEditorProps<SubmitStepElement, Application>): JSX.Element {
     return (
@@ -58,6 +59,18 @@ export function SubmitComponentEditor(props: BaseEditorProps<SubmitStepElement, 
                 allowEmpty
                 addLabel="Dokument hinzufügen"
                 noItemsHint="Keine Dokumente angegeben"
+            />
+
+            <CheckboxFieldComponent
+                label="Konfetti nach dem Absenden deaktivieren"
+                value={props.element.disableConfetti}
+                onChange={(val) => {
+                    props.onPatch({
+                        disableConfetti: val,
+                    });
+                }}
+                disabled={!props.editable}
+                hint="Wenn aktiviert, wird nach erfolgreicher Antragseinreichung keine Konfetti-Animation angezeigt."
             />
         </>
     );

--- a/app/src/components/submitted/submitted.tsx
+++ b/app/src/components/submitted/submitted.tsx
@@ -55,6 +55,7 @@ export function Submitted(props: SubmittedProps): JSX.Element {
     const api = useApi();
     const application = useSelector(selectLoadedForm);
     const submitStep = application?.root.submitStep;
+    const confettiDisabled = submitStep?.disableConfetti === true;
 
     const [status, setStatus] = useState<SubmissionStatusResponseDTO>();
 
@@ -222,18 +223,31 @@ export function Submitted(props: SubmittedProps): JSX.Element {
     }, [intervalId]);
 
     useEffect(() => {
+        if (confettiDisabled) {
+            return;
+        }
+
         setTimeout(() => {
             startAnimation();
         }, animationStartDelay);
-    }, []);
+    }, [confettiDisabled, startAnimation]);
 
     useEffect(() => {
+        if (confettiDisabled) {
+            return;
+        }
+
         setTimeout(() => {
             pauseAnimation();
         }, animationDuration);
-    }, []);
+    }, [confettiDisabled, pauseAnimation]);
 
     useEffect(() => {
+        if (confettiDisabled) {
+            setShouldRenderConfetti(false);
+            return;
+        }
+
         const mediaQuery = window.matchMedia('(prefers-reduced-motion: no-preference)');
         const handleChange = () => {
             setShouldRenderConfetti(mediaQuery.matches);
@@ -243,7 +257,7 @@ export function Submitted(props: SubmittedProps): JSX.Element {
         return () => {
             mediaQuery.removeEventListener('change', handleChange);
         };
-    }, []);
+    }, [confettiDisabled]);
 
     return (
         <>
@@ -549,7 +563,7 @@ export function Submitted(props: SubmittedProps): JSX.Element {
                 />
             </Box>
 
-            {shouldRenderConfetti && (
+            {!confettiDisabled && shouldRenderConfetti && (
                 <ReactCanvasConfetti
                     refConfetti={getInstance}
                     // @ts-expect-error

--- a/app/src/models/elements/steps/submit-step-element.ts
+++ b/app/src/models/elements/steps/submit-step-element.ts
@@ -6,4 +6,5 @@ export interface SubmitStepElement extends BaseElement<ElementType.SubmitStep> {
     textPostSubmit?: string;
     textProcessingTime?: string;
     documentsToReceive?: string[];
+    disableConfetti?: boolean;
 }

--- a/app/src/utils/generate-element-with-default-values.ts
+++ b/app/src/utils/generate-element-with-default-values.ts
@@ -208,6 +208,7 @@ export function generateElementWithDefaultValues<T extends ElementType>(type: T)
                 appVersion,
                 textPreSubmit: 'Sie können Ihren Antrag nun verbindlich bei der zuständigen/bewirtschaftenden Stelle einreichen. Nach der Einreichung können Sie sich den Antrag für Ihre Unterlagen herunterladen oder zusenden lassen.',
                 textPostSubmit: 'Sie können Ihren Antrag herunterladen oder sich per E-Mail zuschicken lassen. Wir empfehlen Ihnen, den Antrag anschließend zu Ihren Unterlagen zu nehmen.',
+                disableConfetti: false,
             };
         case ElementType.SummaryStep:
             return {

--- a/src/main/java/de/aivot/GoverBackend/elements/models/steps/SubmitStepElement.java
+++ b/src/main/java/de/aivot/GoverBackend/elements/models/steps/SubmitStepElement.java
@@ -14,6 +14,7 @@ public class SubmitStepElement extends BaseElement {
     private String textPostSubmit;
     private String textProcessingTime;
     private Collection<String> documentsToReceive;
+    private Boolean disableConfetti;
 
     public SubmitStepElement(Map<String, Object> data) {
         super(data);
@@ -25,6 +26,7 @@ public class SubmitStepElement extends BaseElement {
         textPostSubmit = MapUtils.getString(values, "textPostSubmit");
         textProcessingTime = MapUtils.getString(values, "textProcessingTime");
         documentsToReceive = MapUtils.getStringCollection(values, "documentsToReceive");
+        disableConfetti = MapUtils.getBoolean(values, "disableConfetti", false);
     }
 
     @Override
@@ -41,7 +43,9 @@ public class SubmitStepElement extends BaseElement {
             return false;
         if (!Objects.equals(textProcessingTime, that.textProcessingTime))
             return false;
-        return Objects.equals(documentsToReceive, that.documentsToReceive);
+        if (!Objects.equals(documentsToReceive, that.documentsToReceive))
+            return false;
+        return Objects.equals(disableConfetti, that.disableConfetti);
     }
 
     @Override
@@ -51,6 +55,7 @@ public class SubmitStepElement extends BaseElement {
         result = 31 * result + (textPostSubmit != null ? textPostSubmit.hashCode() : 0);
         result = 31 * result + (textProcessingTime != null ? textProcessingTime.hashCode() : 0);
         result = 31 * result + (documentsToReceive != null ? documentsToReceive.hashCode() : 0);
+        result = 31 * result + (disableConfetti != null ? disableConfetti.hashCode() : 0);
         return result;
     }
 
@@ -86,6 +91,14 @@ public class SubmitStepElement extends BaseElement {
 
     public void setDocumentsToReceive(Collection<String> documentsToReceive) {
         this.documentsToReceive = documentsToReceive;
+    }
+
+    public Boolean getDisableConfetti() {
+        return disableConfetti;
+    }
+
+    public void setDisableConfetti(Boolean disableConfetti) {
+        this.disableConfetti = disableConfetti;
     }
 
     // endregion


### PR DESCRIPTION
# Description

Sometimes it might be a good idea to disable the confetti after a successful submit.