### PR TITLE
fix: update Keycloak hostname config to v2 format and add custom CA example

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -195,6 +195,8 @@ services:
     image: ghcr.io/aivot-digital/gover:4.6.0
     restart: always
     command: staff
+    environment:
+      GOVER_HOSTNAME: "https://{{ HOSTNAME }}" # Die Adresse wird vom Entrypoint-Skript für den Health-Check der API benötigt. Passen Sie den Hostnamen unbedingt an.
     networks:
       - common
     labels:
@@ -208,6 +210,8 @@ services:
     image: ghcr.io/aivot-digital/gover:4.6.0
     restart: always
     command: customer
+    environment:
+      GOVER_HOSTNAME: "https://{{ HOSTNAME }}" # Die Adresse wird vom Entrypoint-Skript für den Health-Check der API benötigt. Passen Sie den Hostnamen unbedingt an.
     networks:
       - common
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,6 +103,11 @@ services:
       KC_SPI_EGOV_BAYERNID_DISPLAY_DESCRIPTION: "{{ ORG_DESCRIPTION }}" # Setzen Sie die Beschreibung Ihrer Organisation. Diese Beschreibung wird an den BayernID-Service übermittelt. Die Beschreibung sollte nicht mehr als 50 Zeichen enthalten. Die Beschreibung wird auf der Login-Seite des BayernID-Service angezeigt.
 
       QUARKUS_HTTP_LIMITS_MAX_FORM_ATTRIBUTE_SIZE: "10M"
+    # Wenn Keycloak eine Verbindung zu einem LDAP-Server oder einem anderen Dienst mit einem selbstsignierten oder internen CA-Zertifikat herstellen soll,
+    # muss das Root-CA-Zertifikat in den Keycloak-Truststore eingebunden werden.
+    # Entfernen Sie die Kommentarzeichen und passen Sie den Pfad zum Zertifikat an.
+    # volumes:
+    #   - /pfad/zum/custom-ca.pem:/opt/keycloak/conf/truststores/custom-ca.pem:ro
     networks:
       - keycloak
       - common

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,8 +72,7 @@ services:
     environment:
       KC_HTTP_ENABLED: true
       KC_PROXY_HEADERS: xforwarded
-      KC_HOSTNAME: "{{ HOSTNAME }}" # Setzen Sie den Hostnamen unter dem Keycloak erreichbar ist. Passen Sie diesen Hostnamen unbedingt an.
-      KC_HOSTNAME_PATH: /idp
+      KC_HOSTNAME: "https://{{ HOSTNAME }}/idp" # Setzen Sie die vollständige URL unter der Keycloak erreichbar ist (inkl. Protokoll und Pfad). Passen Sie diese URL unbedingt an.
       KC_HTTP_RELATIVE_PATH: /idp
 
       KC_HEALTH_ENABLED: true


### PR DESCRIPTION
## Summary

- Replace deprecated Keycloak v1 hostname options (`KC_HOSTNAME` + `KC_HOSTNAME_PATH`) with the v2 format (`KC_HOSTNAME` as full URL) in the example docker-compose.yml
- Add a commented-out example showing how to mount a custom root CA certificate into the Keycloak truststore
- Add missing `GOVER_HOSTNAME` environment variable to `gover_staff_app` and `gover_customer_app` services

## Background

We recently upgraded our Gover installation from 4.5.3 to 4.6.0, which also brought Keycloak 26.5.3. After the upgrade, Traefik returned "Bad Gateway" errors for all `/idp` routes. 

The root cause was that Keycloak 26.x deprecated the v1 hostname configuration (`KC_HOSTNAME` as plain hostname + `KC_HOSTNAME_PATH`). With these settings, Keycloak generated redirect URLs containing the internal port 8080 (e.g., `http://hostname:8080/idp/admin/`), which are unreachable from outside the container network. Switching `KC_HOSTNAME` to the full URL format (`https://hostname/idp`) resolved the issue.

Additionally, the `gover_staff_app` and `gover_customer_app` services were missing the `GOVER_HOSTNAME` environment variable. The entrypoint script uses this variable to perform an API health check before starting nginx. Without it, `curl` receives an invalid URL and the containers loop forever, never starting.

The custom root CA example is a smaller addition — we needed it when setting up LDAP authentication against our Active Directory in a Keycloak realm. Since unencrypted LDAP access is not an option for us, we had to mount our internal CA certificate into the Keycloak truststore directory. We thought this might save others some time figuring out the correct mount path.

Feel free to pull these changes if you find them useful for the project!

## Test plan

- [x] Verified the fix on our production Gover 4.6.0 installation with Keycloak 26.5.3
- [x] Confirmed Keycloak generates correct redirect URLs with the v2 hostname format
- [x] Confirmed LDAPS connectivity works with custom CA mounted to `/opt/keycloak/conf/truststores/`
- [x] Confirmed staff and customer apps start successfully with `GOVER_HOSTNAME` set