### PR TITLE
fix: conditionally render payment method row in form

### DIFF
--- a/src/main/resources/templates/form.html
+++ b/src/main/resources/templates/form.html
@@ -703,7 +703,10 @@
                                 </ul>
                             </td>
                         </tr>
-                        <tr style="vertical-align: top">
+                        <tr
+                                th:if="${ paymentTransaction.paymentInformation.paymentMethod != null }"
+                                style="vertical-align: top"
+                        >
                             <td>
                                 <strong>Zahlungsmittel:</strong>
                             </td>


### PR DESCRIPTION
# Description
ePayBL sometimes returns a payment method with the value `null`. This undocumented behaviour produces an NPE in the default form template rendering. 