### PR TITLE
fix: pin Traefik backend network on multi-homed routed services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,6 +116,7 @@ services:
       - "traefik.http.services.keycloak.loadbalancer.server.port=8080"
       - "traefik.http.routers.keycloak.tls=true" # Aktivieren Sie die TLS-Verschlüsselung für den Reverse-Proxy Traefik. Falls Sie keine TLS-Verschlüsselung verwenden möchten oder diese extern realisiert wird, entfernen Sie diese Zeile.
       - "traefik.http.routers.keycloak.tls.certresolver=ssl_resolver" # Aktivieren Sie die TLS-Verschlüsselung für den Reverse-Proxy Traefik. Falls Sie keine TLS-Verschlüsselung verwenden möchten oder diese extern realisiert wird, entfernen Sie diese Zeile.
+      - "traefik.docker.network=gover_common" # Bindet Traefik an das untenstehende `common`-Netzwerk. Bei Containern mit mehreren Netzwerken zwingend erforderlich, da Traefik sonst zufällig eines auswählt.
 
 
   gover:
@@ -189,6 +190,7 @@ services:
       - "traefik.http.services.gover_api.loadbalancer.server.port=8080"
       - "traefik.http.routers.gover_api.tls=true" # Aktivieren Sie die TLS-Verschlüsselung für den Reverse-Proxy Traefik. Falls Sie keine TLS-Verschlüsselung verwenden möchten oder diese extern realisiert wird, entfernen Sie diese Zeile.
       - "traefik.http.routers.gover_api.tls.certresolver=ssl_resolver" # Aktivieren Sie die TLS-Verschlüsselung für den Reverse-Proxy Traefik. Falls Sie keine TLS-Verschlüsselung verwenden möchten oder diese extern realisiert wird, entfernen Sie diese Zeile.
+      - "traefik.docker.network=gover_common" # Bindet Traefik an das untenstehende `common`-Netzwerk. Bei Containern mit mehreren Netzwerken zwingend erforderlich, da Traefik sonst zufällig eines auswählt.
 
 
   gover_staff_app:
@@ -261,3 +263,4 @@ networks:
   keycloak:
   gover:
   common:
+    name: gover_common # Expliziter Netzwerkname, damit der Wert von `traefik.docker.network` unabhängig vom Compose-Projektnamen funktioniert.


### PR DESCRIPTION
## Problem

The compose template multi-homes `gover` (gover + common) and `keycloak` (keycloak + common) without setting `traefik.docker.network`. When a routed container is attached to multiple Docker networks and the label is absent, Traefik picks one at random. If Traefik picks a network it isn't itself attached to (Traefik sits only on `common`), requests to that backend silently time out: TLS handshake succeeds, the HTTP request is forwarded toward an unreachable IP, no error in Traefik's own logs.

The selection is re-rolled on every Traefik config rebuild (startup + Docker container events), so the failure manifests sporadically across restarts and is easy to misdiagnose as a backend or DNS issue.

## Fix

- Set `traefik.docker.network=gover_common` on the two multi-homed routed backends (`keycloak`, `gover`).
- Pin the `common` network's name via the compose `name:` field, so the label value does not depend on the deployer's compose project name.

## Operator note

On upgrade, the previously project-prefixed `<project>_common` network becomes orphaned (zero containers). It can be cleaned up with `docker network rm <project>_common` after the next stack restart.