### PR TITLE
feat: add process URL namespaces and update URL scheme for public form and webhook routes

### DIFF
--- a/app/src/components/form/root.component.editor.tsx
+++ b/app/src/components/form/root.component.editor.tsx
@@ -4,35 +4,21 @@ import {type BaseEditorProps} from '../../editors/base-editor';
 import {type FormLayoutElement} from '../../models/elements/form-layout-element';
 import {SelectFieldComponent} from '../select-field/select-field-component';
 import {useAppDispatch} from '../../hooks/use-app-dispatch';
-import {showErrorSnackbar, showSuccessSnackbar} from '../../slices/snackbar-slice';
+import {showErrorSnackbar} from '../../slices/snackbar-slice';
 import {TextFieldComponent} from '../text-field/text-field-component';
 import {type SelectFieldComponentOption} from '../select-field/select-field-component-option';
-import ContentPasteOutlinedIcon from '@mui/icons-material/ContentPasteOutlined';
 import {useApi} from '../../hooks/use-api';
 import {Link} from 'react-router-dom';
 import {Hint} from '../hint/hint';
 import {RichTextInputComponent} from '../rich-text-input-component/rich-text-input-component';
 import {CheckboxFieldComponent} from '../checkbox-field/checkbox-field-component';
 import {ThemesApiService} from '../../modules/themes/themes-api-service';
-import QrCode2OutlinedIcon from '@mui/icons-material/QrCode2Outlined';
-import {downloadQrCode} from '../../utils/download-qrcode';
 import {ElementEditorSectionHeader} from '../element-editor-section-header/element-editor-section-header';
 import {withDelay} from '../../utils/with-delay';
-import {copyToClipboardText} from '../../utils/copy-to-clipboard';
 import {AssetSelector} from '../../modules/assets/components/asset-selector';
 import {type VDepartmentShadowedEntity} from '../../modules/departments/entities/v-department-shadowed-entity';
 import {VDepartmentShadowedApiService} from '../../modules/departments/services/v-department-shadowed-api-service';
 import {DepartmentSelectField} from '../../modules/departments/components/department-select-field';
-import {SelectDepartmentDialog} from '../../modules/departments/dialogs/select-department-dialog';
-
-type DepartmentDialogTarget =
-    'responsible' |
-    'managing' |
-    'imprint' |
-    'privacy' |
-    'accessibility' |
-    'legalSupport' |
-    'technicalSupport';
 
 export function RootComponentEditor(props: BaseEditorProps<FormLayoutElement>) {
     const dispatch = useAppDispatch();
@@ -45,16 +31,6 @@ export function RootComponentEditor(props: BaseEditorProps<FormLayoutElement>) {
 
     const [departments, setDepartments] = useState<VDepartmentShadowedEntity[] | null>(null);
     const [themes, setThemes] = useState<SelectFieldComponentOption[] | null>(null);
-    const [activeDepartmentDialog, setActiveDepartmentDialog] = useState<DepartmentDialogTarget | null>(null);
-
-    const handleDownloadQrCode = async (link: string, filename: string) => {
-        try {
-            await downloadQrCode(link, filename);
-            dispatch(showSuccessSnackbar('QR-Code wurde als PNG heruntergeladen!'));
-        } catch {
-            dispatch(showErrorSnackbar('Fehler beim Herunterladen des QR-Codes!'));
-        }
-    };
 
     useEffect(() => {
         withDelay(
@@ -102,72 +78,6 @@ export function RootComponentEditor(props: BaseEditorProps<FormLayoutElement>) {
     const accessibilityDepartment = getDepartmentById(form.accessibilityDepartmentId);
     const legalSupportDepartment = getDepartmentById(form.legalSupportDepartmentId);
     const technicalSupportDepartment = getDepartmentById(form.technicalSupportDepartmentId);
-
-    const handleSelectDepartment = (departmentId: number) => {
-        switch (activeDepartmentDialog) {
-            case 'responsible':
-                onPatch({
-                    responsibleDepartmentId: departmentId,
-                });
-                return;
-            case 'managing':
-                onPatch({
-                    managingDepartmentId: departmentId,
-                });
-                return;
-            case 'imprint':
-                onPatch({
-                    imprintDepartmentId: departmentId,
-                });
-                return;
-            case 'privacy':
-                onPatch({
-                    privacyDepartmentId: departmentId,
-                });
-                return;
-            case 'accessibility':
-                onPatch({
-                    accessibilityDepartmentId: departmentId,
-                });
-                return;
-            case 'legalSupport':
-                onPatch({
-                    legalSupportDepartmentId: departmentId,
-                });
-                return;
-            case 'technicalSupport':
-                onPatch({
-                    technicalSupportDepartmentId: departmentId,
-                });
-                return;
-            default:
-                return;
-        }
-    };
-
-    const getActiveDepartmentId = (): number | null | undefined => {
-        switch (activeDepartmentDialog) {
-            case 'responsible':
-                return form.responsibleDepartmentId;
-            case 'managing':
-                return form.managingDepartmentId;
-            case 'imprint':
-                return form.imprintDepartmentId;
-            case 'privacy':
-                return form.privacyDepartmentId;
-            case 'accessibility':
-                return form.accessibilityDepartmentId;
-            case 'legalSupport':
-                return form.legalSupportDepartmentId;
-            case 'technicalSupport':
-                return form.technicalSupportDepartmentId;
-            default:
-                return null;
-        }
-    };
-
-    const generalLink = ''; //TODO: createCustomerPath(`${props.entity?.form.slug ?? ''}`);
-    const versionedLink = ''; //TODO: createCustomerPath(`${props.entity?.form.slug ?? ''}/${form.version ?? ''}`);
 
     return (
         <>
@@ -240,88 +150,6 @@ export function RootComponentEditor(props: BaseEditorProps<FormLayoutElement>) {
                     />
                 </Grid>
             </Grid>
-            <Grid
-                container
-                columnSpacing={4}
-            >
-                <Grid
-                    size={{
-                        xs: 12,
-                        lg: 6,
-                    }}
-                >
-                    <TextFieldComponent
-                        label="Allgemeiner Link des Formulars"
-                        disabled
-                        onChange={() => {
-                        }}
-                        value={generalLink}
-                        hint="Wenn Sie immer die aktuellste Version des Formulars verlinken möchten, dann wählen Sie den Link ohne Versionierung. Es wird immer das zuletzt veröffentlichte Formular unter diesem Link angezeigt."
-                        endAction={
-                            [
-                                {
-                                    icon: <ContentPasteOutlinedIcon/>,
-                                    tooltip: 'Link in Zwischenablage kopieren',
-                                    onClick: async () => {
-                                        const success = await copyToClipboardText(generalLink);
-                                        if (success) {
-                                            dispatch(showSuccessSnackbar('Link in Zwischenablage kopiert!'));
-                                        } else {
-                                            dispatch(showErrorSnackbar('Fehler beim Kopieren des Links!'));
-                                        }
-                                    },
-                                },
-                                {
-                                    icon: <QrCode2OutlinedIcon/>,
-                                    tooltip: 'QR-Code herunterladen',
-                                    onClick: async () => {
-                                        //TODO: await handleDownloadQrCode(generalLink, `qr-code-${props.entity?.form.slug ?? ''}.png`);
-                                    },
-                                },
-                            ]
-                        }
-                    />
-                </Grid>
-                <Grid
-                    size={{
-                        xs: 12,
-                        lg: 6,
-                    }}
-                >
-
-                    <TextFieldComponent
-                        label="Versionsspezifischer Link des Formulars"
-                        disabled
-                        onChange={() => {
-                        }}
-                        value={versionedLink}
-                        hint="Wenn Sie die explizite Version eines Formulars verlinken möchten, dann wählen Sie den Link inkl. Versionierung. Sobald Sie eine andere Version des Formulars nutzen möchten, müssen Sie den Link z.B. auf Ihrer Webseite entsprechend austauschen."
-                        endAction={
-                            [
-                                {
-                                    icon: <ContentPasteOutlinedIcon/>,
-                                    tooltip: 'Link in Zwischenablage kopieren',
-                                    onClick: async () => {
-                                        const success = await copyToClipboardText(versionedLink);
-                                        if (success) {
-                                            dispatch(showSuccessSnackbar('Link in Zwischenablage kopiert!'));
-                                        } else {
-                                            dispatch(showErrorSnackbar('Fehler beim Kopieren des Links!'));
-                                        }
-                                    },
-                                },
-                                {
-                                    icon: <QrCode2OutlinedIcon/>,
-                                    tooltip: 'QR-Code herunterladen',
-                                    onClick: async () => {
-                                        // TODO: await handleDownloadQrCode(versionedLink, `qr-code-${props.entity?.form.slug ?? ''}-${(form.version ?? '')}.png`);
-                                    },
-                                },
-                            ]
-                        }
-                    />
-                </Grid>
-            </Grid>
             <ElementEditorSectionHeader
                 title="Zuständige Organisationseinheiten"
                 variant="h5"
@@ -351,12 +179,9 @@ export function RootComponentEditor(props: BaseEditorProps<FormLayoutElement>) {
                         <DepartmentSelectField
                             label="Zuständige Organisationseinheit"
                             value={responsibleDepartment}
-                            onOpenDialog={() => {
-                                setActiveDepartmentDialog('responsible');
-                            }}
-                            onClear={() => {
+                            onChange={(department) => {
                                 onPatch({
-                                    responsibleDepartmentId: null,
+                                    responsibleDepartmentId: department?.id ?? null,
                                 });
                             }}
                             disabled={!props.editable}
@@ -381,12 +206,9 @@ export function RootComponentEditor(props: BaseEditorProps<FormLayoutElement>) {
                         <DepartmentSelectField
                             label="Bewirtschaftende Organisationseinheit"
                             value={managingDepartment}
-                            onOpenDialog={() => {
-                                setActiveDepartmentDialog('managing');
-                            }}
-                            onClear={() => {
+                            onChange={(department) => {
                                 onPatch({
-                                    managingDepartmentId: null,
+                                    managingDepartmentId: department?.id ?? null,
                                 });
                             }}
                             disabled={!props.editable}
@@ -424,12 +246,9 @@ export function RootComponentEditor(props: BaseEditorProps<FormLayoutElement>) {
                         <DepartmentSelectField
                             label="Text für das Impressum"
                             value={imprintDepartment}
-                            onOpenDialog={() => {
-                                setActiveDepartmentDialog('imprint');
-                            }}
-                            onClear={() => {
+                            onChange={(department) => {
                                 onPatch({
-                                    imprintDepartmentId: null,
+                                    imprintDepartmentId: department?.id ?? null,
                                 });
                             }}
                             disabled={!props.editable}
@@ -454,12 +273,9 @@ export function RootComponentEditor(props: BaseEditorProps<FormLayoutElement>) {
                         <DepartmentSelectField
                             label="Text für die Datenschutzerklärung"
                             value={privacyDepartment}
-                            onOpenDialog={() => {
-                                setActiveDepartmentDialog('privacy');
-                            }}
-                            onClear={() => {
+                            onChange={(department) => {
                                 onPatch({
-                                    privacyDepartmentId: null,
+                                    privacyDepartmentId: department?.id ?? null,
                                 });
                             }}
                             disabled={!props.editable}
@@ -484,12 +300,9 @@ export function RootComponentEditor(props: BaseEditorProps<FormLayoutElement>) {
                         <DepartmentSelectField
                             label="Text für die Erklärung der Barrierefreiheit"
                             value={accessibilityDepartment}
-                            onOpenDialog={() => {
-                                setActiveDepartmentDialog('accessibility');
-                            }}
-                            onClear={() => {
+                            onChange={(department) => {
                                 onPatch({
-                                    accessibilityDepartmentId: null,
+                                    accessibilityDepartmentId: department?.id ?? null,
                                 });
                             }}
                             disabled={!props.editable}
@@ -648,12 +461,9 @@ export function RootComponentEditor(props: BaseEditorProps<FormLayoutElement>) {
                         <DepartmentSelectField
                             label="Fachlicher Support"
                             value={legalSupportDepartment}
-                            onOpenDialog={() => {
-                                setActiveDepartmentDialog('legalSupport');
-                            }}
-                            onClear={() => {
+                            onChange={(department) => {
                                 onPatch({
-                                    legalSupportDepartmentId: null,
+                                    legalSupportDepartmentId: department?.id ?? null,
                                 });
                             }}
                             disabled={!props.editable}
@@ -678,12 +488,9 @@ export function RootComponentEditor(props: BaseEditorProps<FormLayoutElement>) {
                         <DepartmentSelectField
                             label="Technischer Support"
                             value={technicalSupportDepartment}
-                            onOpenDialog={() => {
-                                setActiveDepartmentDialog('technicalSupport');
-                            }}
-                            onClear={() => {
+                            onChange={(department) => {
                                 onPatch({
-                                    technicalSupportDepartmentId: null,
+                                    technicalSupportDepartmentId: department?.id ?? null,
                                 });
                             }}
                             disabled={!props.editable}
@@ -691,16 +498,6 @@ export function RootComponentEditor(props: BaseEditorProps<FormLayoutElement>) {
                     }
                 </Grid>
             </Grid>
-            <SelectDepartmentDialog
-                open={activeDepartmentDialog != null}
-                onClose={() => {
-                    setActiveDepartmentDialog(null);
-                }}
-                onSelect={(department) => {
-                    handleSelectDepartment(department.id);
-                }}
-                selectedDepartmentId={getActiveDepartmentId()}
-            />
             <ElementEditorSectionHeader
                 title="Hinweise zur Offline-Einreichung"
                 variant="h5"

--- a/app/src/components/form/root.component.editor.tsx
+++ b/app/src/components/form/root.component.editor.tsx
@@ -251,6 +251,7 @@ export function RootComponentEditor(props: BaseEditorProps<FormLayoutElement>) {
                                     imprintDepartmentId: department?.id ?? null,
                                 });
                             }}
+                            required
                             disabled={!props.editable}
                         />
                     }
@@ -278,6 +279,7 @@ export function RootComponentEditor(props: BaseEditorProps<FormLayoutElement>) {
                                     privacyDepartmentId: department?.id ?? null,
                                 });
                             }}
+                            required
                             disabled={!props.editable}
                         />
                     }
@@ -305,6 +307,7 @@ export function RootComponentEditor(props: BaseEditorProps<FormLayoutElement>) {
                                     accessibilityDepartmentId: department?.id ?? null,
                                 });
                             }}
+                            required
                             disabled={!props.editable}
                         />
                     }
@@ -466,6 +469,7 @@ export function RootComponentEditor(props: BaseEditorProps<FormLayoutElement>) {
                                     legalSupportDepartmentId: department?.id ?? null,
                                 });
                             }}
+                            required
                             disabled={!props.editable}
                         />
                     }
@@ -493,6 +497,7 @@ export function RootComponentEditor(props: BaseEditorProps<FormLayoutElement>) {
                                     technicalSupportDepartmentId: department?.id ?? null,
                                 });
                             }}
+                            required
                             disabled={!props.editable}
                         />
                     }

--- a/app/src/modules/departments/components/department-select-field.tsx
+++ b/app/src/modules/departments/components/department-select-field.tsx
@@ -1,35 +1,40 @@
 import {Box, IconButton, InputAdornment, TextField, Tooltip, Typography} from '@mui/material';
 import ChevronRight from '@mui/icons-material/ChevronRight';
 import Close from '@mui/icons-material/Close';
-import React from 'react';
-import {type VDepartmentShadowedEntity} from '../entities/v-department-shadowed-entity';
+import React, {useState} from 'react';
+import {type VDepartmentShadowedEntity, type VDepartmentShadowedEntityWithChildren} from '../entities/v-department-shadowed-entity';
 import {getDepartmentPath, getDepartmentTypeIcons} from '../utils/department-utils';
 import GroupWork from '@aivot/mui-material-symbols-400-outlined/dist/group-work/GroupWork';
+import {SelectDepartmentDialog} from '../dialogs/select-department-dialog';
 
 interface DepartmentSelectFieldProps {
     label: string;
     value?: VDepartmentShadowedEntity | null;
-    onOpenDialog: () => void;
-    onClear: () => void;
+    onChange: (department: VDepartmentShadowedEntityWithChildren | null) => void;
     disabled?: boolean;
     error?: string;
     hint?: string;
     placeholder?: string;
     required?: boolean;
+    dialogTitle?: string;
+    departments?: VDepartmentShadowedEntityWithChildren[];
 }
 
 export function DepartmentSelectField(props: DepartmentSelectFieldProps): React.ReactElement {
     const {
         label,
         value,
-        onOpenDialog,
-        onClear,
+        onChange,
         disabled = false,
         error,
         hint,
         placeholder = 'Keine Organisationseinheit ausgewählt',
         required = false,
+        dialogTitle = 'Organisationseinheit auswählen',
+        departments,
     } = props;
+
+    const [showSelectDepartmentDialog, setShowSelectDepartmentDialog] = useState(false);
     const showDepartmentPath = value != null && (value.parentNames?.length ?? 0) > 0;
     const departmentPath = showDepartmentPath ? getDepartmentPath(value) : undefined;
     const departmentIcon = value != null ? getDepartmentTypeIcons(value.depth) : <GroupWork />;
@@ -41,9 +46,15 @@ export function DepartmentSelectField(props: DepartmentSelectFieldProps): React.
     const endIconColor = disabled ? 'text.disabled' : 'action.active';
     const clearTooltip = disabled || value == null ? '' : 'Auswahl entfernen';
 
+    const handleOpenDialog = () => {
+        if (!disabled) {
+            setShowSelectDepartmentDialog(true);
+        }
+    };
+
     const handleClear = (event: React.MouseEvent<HTMLButtonElement>) => {
         event.stopPropagation();
-        onClear();
+        onChange(null);
     };
 
     const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -53,187 +64,200 @@ export function DepartmentSelectField(props: DepartmentSelectFieldProps): React.
 
         if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault();
-            onOpenDialog();
+            setShowSelectDepartmentDialog(true);
         }
     };
 
     return (
-        <TextField
-            fullWidth
-            label={label}
-            value={fieldValue}
-            placeholder={placeholder}
-            error={error != null}
-            helperText={error ?? hint}
-            required={required}
-            onClick={() => {
-                if (!disabled) {
-                    onOpenDialog();
-                }
-            }}
-            onKeyDown={handleKeyDown}
-            InputLabelProps={{
-                title: label,
-            }}
-            FormHelperTextProps={{
-                title: error ?? hint,
-                sx: {
-                    whiteSpace: 'normal',
-                },
-            }}
-            inputProps={{
-                readOnly: true,
-                title: value?.name,
-                'aria-label': label,
-            }}
-            InputProps={{
-                startAdornment: (
-                    <InputAdornment
-                        position="start"
-                        sx={{
-                            minWidth: 0,
-                            flex: 1,
-                            alignItems: 'center',
-                            mr: 1,
-                        }}
-                    >
-                        <Box
-                            component="span"
-                            sx={{
-                                display: 'inline-flex',
-                                flexShrink: 0,
-                                mr: 1.25,
-                                color: iconColor,
-                                '& .MuiSvgIcon-root': {
-                                    fontSize: 20,
-                                },
-                            }}
-                        >
-                            {departmentIcon}
-                        </Box>
-
-                        <Box
-                            component="span"
+        <>
+            <TextField
+                fullWidth
+                label={label}
+                value={fieldValue}
+                placeholder={placeholder}
+                disabled={disabled}
+                error={error != null}
+                helperText={error ?? hint}
+                required={required}
+                onClick={handleOpenDialog}
+                onKeyDown={handleKeyDown}
+                InputLabelProps={{
+                    title: label,
+                }}
+                FormHelperTextProps={{
+                    title: error ?? hint,
+                    sx: {
+                        whiteSpace: 'normal',
+                    },
+                }}
+                inputProps={{
+                    readOnly: true,
+                    title: value?.name,
+                    'aria-label': label,
+                }}
+                InputProps={{
+                    startAdornment: (
+                        <InputAdornment
+                            position="start"
                             sx={{
                                 minWidth: 0,
                                 flex: 1,
+                                alignItems: 'center',
+                                mr: 1,
                             }}
                         >
-                            {
-                                value != null ? (
-                                    <>
-                                        <Typography
-                                            variant="body2"
-                                            component="span"
-                                            color={primaryContentColor}
-                                            sx={{
-                                                display: 'block',
-                                                overflow: 'hidden',
-                                                textOverflow: 'ellipsis',
-                                                whiteSpace: 'nowrap',
-                                                fontSize: '1rem',
-                                                lineHeight: 1.25,
-                                            }}
-                                            title={value.name}
-                                        >
-                                            {value.name}
-                                        </Typography>
+                            <Box
+                                component="span"
+                                sx={{
+                                    display: 'inline-flex',
+                                    flexShrink: 0,
+                                    mr: 1.25,
+                                    color: iconColor,
+                                    '& .MuiSvgIcon-root': {
+                                        fontSize: 20,
+                                    },
+                                }}
+                            >
+                                {departmentIcon}
+                            </Box>
 
-                                        {
-                                            departmentPath != null &&
+                            <Box
+                                component="span"
+                                sx={{
+                                    minWidth: 0,
+                                    flex: 1,
+                                }}
+                            >
+                                {
+                                    value != null ? (
+                                        <>
                                             <Typography
-                                                variant="caption"
+                                                variant="body2"
                                                 component="span"
-                                                color={secondaryContentColor}
+                                                color={primaryContentColor}
                                                 sx={{
                                                     display: 'block',
                                                     overflow: 'hidden',
                                                     textOverflow: 'ellipsis',
                                                     whiteSpace: 'nowrap',
-                                                    fontSize: '0.75rem',
-                                                    lineHeight: 1.2,
+                                                    fontSize: '1rem',
+                                                    lineHeight: 1.25,
                                                 }}
-                                                title={departmentPath}
+                                                title={value.name}
                                             >
-                                                {departmentPath}
+                                                {value.name}
                                             </Typography>
-                                        }
-                                    </>
-                                ) : (
-                                    <Typography
-                                        variant="body2"
-                                        component="span"
-                                        color={secondaryContentColor}
-                                        sx={{
-                                            display: 'block',
-                                            overflow: 'hidden',
-                                            textOverflow: 'ellipsis',
-                                            whiteSpace: 'nowrap',
-                                        }}
-                                    >
-                                        {placeholder}
-                                    </Typography>
-                                )
-                            }
-                        </Box>
-                    </InputAdornment>
-                ),
-                endAdornment: (
-                    <InputAdornment position="end">
-                        <Box
-                            sx={{
-                                display: 'flex',
-                                alignItems: 'center',
-                                gap: 0.5,
-                                mr: -0.5,
-                            }}
-                        >
-                            <Tooltip
-                                title={clearTooltip}
-                                arrow
-                            >
-                                <span>
-                                    <IconButton
-                                        size="small"
-                                        onClick={handleClear}
-                                        onMouseDown={(event) => {
-                                            event.preventDefault();
-                                            event.stopPropagation();
-                                        }}
-                                        disabled={disabled || value == null}
-                                        aria-label="Auswahl entfernen"
-                                    >
-                                        <Close fontSize="small"/>
-                                    </IconButton>
-                                </span>
-                            </Tooltip>
 
-                            <ChevronRight
-                                fontSize="small"
-                                sx={{color: endIconColor}}
-                            />
-                        </Box>
-                    </InputAdornment>
-                ),
-            }}
-            sx={{
-                '& .MuiOutlinedInput-root': {
-                    cursor: interactiveCursor,
-                    height: 56,
-                    minHeight: 56,
-                },
-                '& .MuiOutlinedInput-input': {
-                    width: 0,
-                    minWidth: 0,
-                    flex: '0 0 0',
-                    p: 0,
-                    cursor: interactiveCursor,
-                    caretColor: 'transparent',
-                },
-                '& .MuiInputAdornment-root': {
-                    pointerEvents: disabled ? 'none' : 'auto',
-                },
-            }}
-        />
+                                            {
+                                                departmentPath != null &&
+                                                <Typography
+                                                    variant="caption"
+                                                    component="span"
+                                                    color={secondaryContentColor}
+                                                    sx={{
+                                                        display: 'block',
+                                                        overflow: 'hidden',
+                                                        textOverflow: 'ellipsis',
+                                                        whiteSpace: 'nowrap',
+                                                        fontSize: '0.75rem',
+                                                        lineHeight: 1.2,
+                                                    }}
+                                                    title={departmentPath}
+                                                >
+                                                    {departmentPath}
+                                                </Typography>
+                                            }
+                                        </>
+                                    ) : (
+                                        <Typography
+                                            variant="body2"
+                                            component="span"
+                                            color={secondaryContentColor}
+                                            sx={{
+                                                display: 'block',
+                                                overflow: 'hidden',
+                                                textOverflow: 'ellipsis',
+                                                whiteSpace: 'nowrap',
+                                            }}
+                                        >
+                                            {placeholder}
+                                        </Typography>
+                                    )
+                                }
+                            </Box>
+                        </InputAdornment>
+                    ),
+                    endAdornment: (
+                        <InputAdornment position="end">
+                            <Box
+                                sx={{
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    gap: 0.5,
+                                    mr: -0.5,
+                                }}
+                            >
+                                <Tooltip
+                                    title={clearTooltip}
+                                    arrow
+                                >
+                                    <span>
+                                        <IconButton
+                                            size="small"
+                                            onClick={handleClear}
+                                            onMouseDown={(event) => {
+                                                event.preventDefault();
+                                                event.stopPropagation();
+                                            }}
+                                            disabled={disabled || value == null}
+                                            aria-label="Auswahl entfernen"
+                                        >
+                                            <Close fontSize="small"/>
+                                        </IconButton>
+                                    </span>
+                                </Tooltip>
+
+                                <ChevronRight
+                                    fontSize="small"
+                                    sx={{color: endIconColor}}
+                                />
+                            </Box>
+                        </InputAdornment>
+                    ),
+                }}
+                sx={{
+                    '& .MuiOutlinedInput-root': {
+                        cursor: interactiveCursor,
+                        height: 56,
+                        minHeight: 56,
+                    },
+                    '& .MuiOutlinedInput-input': {
+                        width: 0,
+                        minWidth: 0,
+                        flex: '0 0 0',
+                        p: 0,
+                        cursor: interactiveCursor,
+                        caretColor: 'transparent',
+                    },
+                    '& .MuiInputAdornment-root': {
+                        pointerEvents: disabled ? 'none' : 'auto',
+                    },
+                }}
+            />
+
+            <SelectDepartmentDialog
+                open={showSelectDepartmentDialog}
+                title={dialogTitle}
+                departments={departments}
+                selectedDepartmentId={value?.id ?? null}
+                onClose={() => {
+                    setShowSelectDepartmentDialog(false);
+                }}
+                onSelect={(department) => {
+                    onChange(department);
+                    setShowSelectDepartmentDialog(false);
+                }}
+            />
+        </>
     );
 }

--- a/app/src/modules/departments/dialogs/select-department-dialog.tsx
+++ b/app/src/modules/departments/dialogs/select-department-dialog.tsx
@@ -13,6 +13,7 @@ interface SelectDepartmentDialogProps {
     onSelect: (department: VDepartmentShadowedEntityWithChildren) => void;
     selectedDepartmentId?: number | null;
     title?: string;
+    departments?: VDepartmentShadowedEntityWithChildren[];
 }
 
 export function SelectDepartmentDialog(props: SelectDepartmentDialogProps): React.ReactElement {
@@ -22,6 +23,7 @@ export function SelectDepartmentDialog(props: SelectDepartmentDialogProps): Reac
         onSelect,
         selectedDepartmentId,
         title = 'Organisationseinheit auswählen',
+        departments: providedDepartments,
     } = props;
 
     const [
@@ -34,7 +36,7 @@ export function SelectDepartmentDialog(props: SelectDepartmentDialogProps): Reac
     ] = useState(false);
 
     useEffect(() => {
-        if (!open) {
+        if (!open || providedDepartments != null) {
             return;
         }
 
@@ -65,7 +67,14 @@ export function SelectDepartmentDialog(props: SelectDepartmentDialogProps): Reac
         return () => {
             active = false;
         };
-    }, [open]);
+    }, [open, providedDepartments]);
+
+    useEffect(() => {
+        if (providedDepartments != null) {
+            setDepartments(providedDepartments);
+            setLoadError(false);
+        }
+    }, [providedDepartments]);
 
     return (
         <Dialog

--- a/app/src/modules/elements/pages/form-node-editor-page.tsx
+++ b/app/src/modules/elements/pages/form-node-editor-page.tsx
@@ -284,9 +284,10 @@ export function FormNodeEditorPage() {
 
         new FormTriggerApiService()
             .getFormTheme(
-                process.accessKey,
+                process.slug,
                 node.configuration.formSlug,
                 processVersion.processVersion,
+                testClaim?.accessKey,
             )
             .then((theme) => {
                 if (!isCancelled) {
@@ -303,7 +304,7 @@ export function FormNodeEditorPage() {
         return () => {
             isCancelled = true;
         };
-    }, [node, process, processVersion]);
+    }, [node, process, processVersion, testClaim]);
 
     const [searchParams] = useSearchParams();
     const metaDialogName = useMemo(() => searchParams.get(DialogSearchParam), [searchParams]);
@@ -422,7 +423,7 @@ export function FormNodeEditorPage() {
 
     const scrollContainerRef = useRef<HTMLDivElement>(null);
 
-    const publicFormLink = createCustomerPath(`/${process?.accessKey}/${node?.configuration.formSlug}${testClaim != null ? `?test-claim=${testClaim.accessKey}` : ''}`);
+    const publicFormLink = createCustomerPath(`/form/${process?.slug}/${node?.configuration.formSlug}${testClaim != null ? `?test-claim=${testClaim.accessKey}` : ''}`);
 
     const handleImportFromXDF = async () => {
         try {
@@ -783,7 +784,7 @@ export function FormNodeEditorPage() {
         formAssetQueryParams.set('test-claim', testClaim.accessKey);
     }
 
-    const formLogoUrl = `/api/public/forms/v1/${process.accessKey}/${node.configuration.formSlug}/logo/?${formAssetQueryParams.toString()}`;
+    const formLogoUrl = `/api/public/form/${process.slug}/${node.configuration.formSlug}/logo/?${formAssetQueryParams.toString()}`;
 
     const handleSubmitEvent = async (values: AuthoredElementValues, event: string): Promise<void> => {
         if (event != SUBMIT_EVENT) {
@@ -925,7 +926,7 @@ export function FormNodeEditorPage() {
                 .postFormData<{
                     startedProcessAccessKey: string;
                 }>(
-                    `/api/public/forms/v1/${process?.accessKey}/${node.configuration.formSlug}/submit/`,
+                    `/api/public/form/${process?.slug}/${node.configuration.formSlug}/submit/`,
                     formData,
                     {
                         query: {

--- a/app/src/modules/forms/services/form-trigger-api-service.ts
+++ b/app/src/modules/forms/services/form-trigger-api-service.ts
@@ -63,7 +63,7 @@ export class FormTriggerApiService extends BaseApiService {
         order?: SortOrder,
         filters?: Partial<FormTriggerFilter>,
     ): Promise<Page<FormTriggerListItem>> {
-        return await this.get<Page<FormTriggerListItem>>('/api/public/forms/v1/', {
+        return await this.get<Page<FormTriggerListItem>>('/api/public/forms/', {
             query: this.buildListQuery(page, limit, sort, order, filters),
             skipAuthCheck: true,
         });
@@ -80,12 +80,12 @@ export class FormTriggerApiService extends BaseApiService {
     }
 
     public async getFormTheme(
-        processAccessKey: string,
+        processSlug: string,
         formSlug: string,
         version?: number,
         testClaimAccessKey?: string,
     ): Promise<Theme> {
-        return await this.get<Theme>(`/api/public/forms/v1/${processAccessKey}/${formSlug}/theme/`, {
+        return await this.get<Theme>(`/api/public/form/${processSlug}/${formSlug}/theme/`, {
             query: {
                 version,
                 'test-claim': testClaimAccessKey,

--- a/app/src/modules/process/components/process-list-row-menu.tsx
+++ b/app/src/modules/process/components/process-list-row-menu.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import {ListItemIcon, ListItemText, Menu, MenuItem} from '@mui/material';
+import MoveItem from '@aivot/mui-material-symbols-400-outlined/dist/move-item/MoveItem';
+import {ProcessEntity} from '../entities/process-entity';
+
+interface ProcessListRowMenuProps {
+    anchorEl: HTMLElement | null;
+    onClose: () => void;
+    process: ProcessEntity;
+    onMoveProcessToDepartment: (process: ProcessEntity) => void;
+}
+
+export function ProcessListRowMenu(props: ProcessListRowMenuProps) {
+    const {
+        anchorEl,
+        onClose,
+        process,
+        onMoveProcessToDepartment,
+    } = props;
+
+    return (
+        <Menu
+            anchorEl={anchorEl}
+            open={anchorEl != null}
+            onClose={onClose}
+        >
+            <MenuItem
+                onClick={() => {
+                    onMoveProcessToDepartment(process);
+                    onClose();
+                }}
+            >
+                <ListItemIcon>
+                    <MoveItem/>
+                </ListItemIcon>
+                <ListItemText>
+                    Prozess an Organisationseinheit übertragen
+                </ListItemText>
+            </MenuItem>
+        </Menu>
+    );
+}

--- a/app/src/modules/process/dialogs/move-process-to-department-dialog.tsx
+++ b/app/src/modules/process/dialogs/move-process-to-department-dialog.tsx
@@ -5,22 +5,19 @@ import {useAppDispatch} from '../../../hooks/use-app-dispatch';
 import {isApiError} from '../../../models/api-error';
 import MoveGroup from '@aivot/mui-material-symbols-400-outlined/dist/move-group/MoveGroup';
 import {DialogTitleWithClose} from '../../../components/dialog-title-with-close/dialog-title-with-close';
-import {SelectFieldComponent} from '../../../components/select-field/select-field-component';
 import {setLoadingMessage} from '../../../slices/shell-slice';
-import {withDelay} from '../../../utils/with-delay';
 import {VDepartmentShadowedEntity} from '../../departments/entities/v-department-shadowed-entity';
-import {VDepartmentShadowedApiService} from '../../departments/services/v-department-shadowed-api-service';
-import {getDepartmentPath} from '../../departments/utils/department-utils';
+import {DepartmentSelectField} from '../../departments/components/department-select-field';
 import {ProcessEntity} from '../entities/process-entity';
 import {ProcessDefinitionApiService} from '../services/process-definition-api-service';
 
-interface MoveFormToDepartmentDialogProps {
+interface MoveProcessToDepartmentDialogProps {
     processId: number;
     onClose: () => void;
-    onMoved: () => void;
+    onMoved: (process: ProcessEntity) => void;
 }
 
-export function MoveProcessToDepartmentDialog(props: MoveFormToDepartmentDialogProps) {
+export function MoveProcessToDepartmentDialog(props: MoveProcessToDepartmentDialogProps) {
     const {
         processId,
         onClose,
@@ -29,61 +26,51 @@ export function MoveProcessToDepartmentDialog(props: MoveFormToDepartmentDialogP
 
     const dispatch = useAppDispatch();
 
-    const [targetDepartmentId, setTargetDepartmentId] = useState<number | null>(null);
+    const [targetDepartment, setTargetDepartment] = useState<VDepartmentShadowedEntity | null>(null);
+    const [targetDepartmentError, setTargetDepartmentError] = useState<string | undefined>();
 
     const [process, setProcess] = useState<ProcessEntity>();
     useEffect(() => {
+        setProcess(undefined);
+        setTargetDepartment(null);
+        setTargetDepartmentError(undefined);
+
         new ProcessDefinitionApiService()
             .retrieve(processId)
             .then(setProcess)
             .catch((err) => {
                 dispatch(showApiErrorSnackbar(err, 'Der Prozess konnte nicht geladen werden.'));
             });
-    }, [processId]);
-
-    const [departments, setDepartments] = useState<VDepartmentShadowedEntity[]>();
-
-    useEffect(() => {
-        withDelay(
-            new VDepartmentShadowedApiService()
-                .listAllOrdered(['parentNames', 'name'], 'ASC'),
-            600,
-        )
-            .then(({content}) => {
-                setDepartments(content);
-            })
-            .catch((err) => {
-                dispatch(showApiErrorSnackbar(err, 'Die Liste der Organisationseinheiten konnte nicht geladen werden.'));
-            });
-    }, []);
+    }, [dispatch, processId]);
 
     const handleMove = () => {
         if (process == null) {
             return;
         }
 
-        if (targetDepartmentId == null) {
-            dispatch(showErrorSnackbar('Bitte wählen Sie eine Organisationseinheit aus, an die das Formular übertragen werden soll.'));
+        if (targetDepartment == null) {
+            setTargetDepartmentError('Bitte wählen Sie eine neue verwaltende Organisationseinheit aus.');
+            dispatch(showErrorSnackbar('Bitte wählen Sie eine Organisationseinheit aus, an die der Prozess übertragen werden soll.'));
             return;
         }
 
         dispatch(setLoadingMessage({
-            message: 'Formular wird übertragen',
+            message: 'Prozess wird übertragen',
             estimatedTime: 500,
             blocking: true,
         }));
 
         new ProcessDefinitionApiService()
-            .move(process.id, targetDepartmentId)
-            .then(() => {
-                dispatch(showSuccessSnackbar('Das Formular wurde erfolgreich übertragen.'));
-                onMoved();
+            .move(process.id, targetDepartment.id)
+            .then((updatedProcess) => {
+                dispatch(showSuccessSnackbar('Der Prozess wurde erfolgreich übertragen.'));
+                onMoved(updatedProcess);
             })
             .catch((err) => {
                 if (isApiError(err) && err.displayableToUser) {
                     dispatch(showErrorSnackbar(err.message));
                 } else {
-                    dispatch(showErrorSnackbar('Das Formular konnte nicht übertragen werden.'));
+                    dispatch(showErrorSnackbar('Der Prozess konnte nicht übertragen werden.'));
                 }
                 console.error(err);
             })
@@ -101,13 +88,12 @@ export function MoveProcessToDepartmentDialog(props: MoveFormToDepartmentDialogP
             <DialogTitleWithClose
                 onClose={onClose}
             >
-                Formular an Organisationseinheit übertragen
+                Prozess an Organisationseinheit übertragen
             </DialogTitleWithClose>
 
             {
-                (process == null || departments == null) &&
+                process == null &&
                 <DialogContent tabIndex={0}>
-                    {/* Skeleton for the first Typography */}
                     <Skeleton
                         variant="text"
                         width="90%"
@@ -117,7 +103,6 @@ export function MoveProcessToDepartmentDialog(props: MoveFormToDepartmentDialogP
                         }}
                     />
 
-                    {/* Skeleton for the second Typography */}
                     <Skeleton
                         variant="text"
                         width="100%"
@@ -128,7 +113,6 @@ export function MoveProcessToDepartmentDialog(props: MoveFormToDepartmentDialogP
                         }}
                     />
 
-                    {/* Skeleton for the SelectFieldComponent */}
                     <Skeleton
                         variant="rectangular"
                         width="100%"
@@ -139,37 +123,44 @@ export function MoveProcessToDepartmentDialog(props: MoveFormToDepartmentDialogP
 
             {
                 process != null &&
-                departments != null &&
                 <DialogContent tabIndex={0}>
                     <Typography
                         variant="body1"
                         gutterBottom={true}
                     >
-                        Bitte wählen Sie die Organisationseinheit aus, an die das Formular <strong>{process.internalTitle}</strong> übertragen werden soll.
+                        Bitte wählen Sie die Organisationseinheit aus, an die der Prozess <strong>{process.internalTitle}</strong> übertragen werden soll.
                     </Typography>
 
                     <Typography
                         variant="body2"
                         gutterBottom={true}
                     >
-                        Bitte beachten Sie, dass Sie möglicherweise nicht mehr auf das Formular zugreifen können, wenn Sie es an eine andere Organisationseinheit übertragen.
+                        Bitte beachten Sie, dass Sie möglicherweise nicht mehr auf den Prozess zugreifen können, wenn Sie ihn an eine andere Organisationseinheit übertragen.
                     </Typography>
 
-                    <SelectFieldComponent
-                        label="Organisation"
-                        value={targetDepartmentId?.toString() ?? undefined}
-                        onChange={(val) => {
-                            const valNumber = val != null ? parseInt(val.toString(), 10) : null;
-                            setTargetDepartmentId(valNumber);
+                    <DepartmentSelectField
+                        label="Neue verwaltende Organisationseinheit"
+                        value={targetDepartment}
+                        dialogTitle="Neue verwaltende Organisationseinheit auswählen"
+                        onChange={(department) => {
+                            if (department == null) {
+                                setTargetDepartment(null);
+                                setTargetDepartmentError(undefined);
+                                return;
+                            }
+
+                            if (department.id === process.departmentId) {
+                                setTargetDepartment(null);
+                                setTargetDepartmentError('Bitte wählen Sie eine andere Organisationseinheit aus.');
+                                return;
+                            }
+
+                            setTargetDepartment(department);
+                            setTargetDepartmentError(undefined);
                         }}
-                        options={
-                            departments
-                                .filter(dep => dep.id !== process.departmentId)
-                                .map(dep => ({
-                                    label: getDepartmentPath(dep),
-                                    value: dep.id.toString(),
-                                }))
-                        }
+                        error={targetDepartmentError}
+                        hint="Wählen Sie die Organisationseinheit aus, die den Prozess künftig verwalten soll."
+                        required
                     />
                 </DialogContent>
             }
@@ -180,9 +171,9 @@ export function MoveProcessToDepartmentDialog(props: MoveFormToDepartmentDialogP
                     color="primary"
                     variant="contained"
                     startIcon={<MoveGroup />}
-                    disabled={process == null || departments == null}
+                    disabled={process == null || targetDepartment == null || targetDepartmentError != null}
                 >
-                    Ja, Formular übertragen
+                    Ja, Prozess übertragen
                 </Button>
                 <Button
                     onClick={onClose}

--- a/app/src/modules/process/dialogs/new-process-dialog.tsx
+++ b/app/src/modules/process/dialogs/new-process-dialog.tsx
@@ -7,8 +7,10 @@ import {
     Button,
     Card,
     CardActionArea,
+    CircularProgress,
     Divider,
     Grid,
+    InputAdornment,
     Step,
     StepLabel,
     type SvgIconProps,
@@ -20,6 +22,7 @@ import Typography from '@mui/material/Typography';
 import UploadFile from '@aivot/mui-material-symbols-400-outlined/dist/upload-file/UploadFile';
 import Check from '@aivot/mui-material-symbols-400-outlined/dist/check/Check';
 import Draft from '@aivot/mui-material-symbols-400-outlined/dist/draft/Draft';
+import LinkIcon from '@aivot/mui-material-symbols-400-outlined/dist/link/Link';
 import {uploadObjectFile} from '../../../utils/download-utils';
 import {type ProcessExport} from '../entities/process-export';
 import {
@@ -48,7 +51,7 @@ import {type StatusTablePropsItem} from '../../../components/status-table/status
 import Label from '@aivot/mui-material-symbols-400-outlined/dist/label/Label';
 import {DepartmentSelectField} from '../../departments/components/department-select-field';
 import {type VDepartmentShadowedEntityWithChildren} from '../../departments/entities/v-department-shadowed-entity';
-import {DepartmentBrowser} from '../../departments/components/department-browser';
+import {normalizeProcessSlugInput, PROCESS_SLUG_MAX_LENGTH, validateProcessSlug} from '../utils/process-slug-utils';
 
 interface NewProcessDialogProps {
     open: boolean;
@@ -77,10 +80,17 @@ export function NewProcessDialog(props: NewProcessDialogProps): ReactNode {
 
     const [availableDepartments, setAvailableDepartments] = useState<VDepartmentShadowedEntityWithChildren[]>();
     const [nameOverride, setNameOverride] = useState<string | null>(null);
+    const [publicTitleOverride, setPublicTitleOverride] = useState<string | null>(preselectedTemplate?.version.publicTitle ?? null);
+    const [publicTitleManuallyEdited, setPublicTitleManuallyEdited] = useState(preselectedTemplate != null && isStringNotNullOrEmpty(preselectedTemplate.version.publicTitle));
+    const [slugOverride, setSlugOverride] = useState<string | null>(null);
+    const [slugManuallyEdited, setSlugManuallyEdited] = useState(false);
     const [departmentOverride, setDepartmentOverride] = useState<number | null>(null);
     const [nameError, setNameError] = useState<string | undefined>();
+    const [publicTitleError, setPublicTitleError] = useState<string | undefined>();
+    const [slugError, setSlugError] = useState<string | undefined>();
+    const [slugAvailabilityError, setSlugAvailabilityError] = useState<string | undefined>();
+    const [isCheckingSlugAvailability, setIsCheckingSlugAvailability] = useState(false);
     const [departmentError, setDepartmentError] = useState<string | undefined>();
-    const [showDepartmentDialog, setShowDepartmentDialog] = useState(false);
 
     const [isLoading, setIsLoading] = useState(false);
 
@@ -100,7 +110,7 @@ export function NewProcessDialog(props: NewProcessDialogProps): ReactNode {
         getDepartmentPath(selectedDepartment) :
         undefined;
 
-    const hasProcessConfigurationErrors = nameError != null || departmentError != null;
+    const hasProcessConfigurationErrors = nameError != null || publicTitleError != null || slugError != null || slugAvailabilityError != null || departmentError != null;
 
     const summaryItems = useMemo<StatusTablePropsItem[]>(() => [
         {
@@ -118,6 +128,24 @@ export function NewProcessDialog(props: NewProcessDialogProps): ReactNode {
             children: (
                 <Typography variant="body2" sx={{overflowWrap: 'anywhere'}}>
                     {nameOverride?.trim() ?? 'Nicht angegeben'}
+                </Typography>
+            ),
+        },
+        {
+            label: 'Öffentliche Bezeichnung',
+            icon: <SummaryIcon><Label/></SummaryIcon>,
+            children: (
+                <Typography variant="body2" sx={{overflowWrap: 'anywhere'}}>
+                    {publicTitleOverride?.trim() ?? 'Nicht angegeben'}
+                </Typography>
+            ),
+        },
+        {
+            label: 'URL-Namespace',
+            icon: <SummaryIcon><LinkIcon/></SummaryIcon>,
+            children: (
+                <Typography variant="body2" sx={{overflowWrap: 'anywhere'}}>
+                    {slugOverride != null ? `/${slugOverride.trim()}` : 'Nicht angegeben'}
                 </Typography>
             ),
         },
@@ -148,7 +176,7 @@ export function NewProcessDialog(props: NewProcessDialogProps): ReactNode {
                 </Typography>
             ),
         },
-    ], [nameOverride, selectedDepartment, selectedDepartmentPath, selectedStartPoint]);
+    ], [nameOverride, publicTitleOverride, selectedDepartment, selectedDepartmentPath, selectedStartPoint, slugOverride]);
 
     useEffect(() => {
         if (user == null) {
@@ -210,6 +238,24 @@ export function NewProcessDialog(props: NewProcessDialogProps): ReactNode {
         return undefined;
     };
 
+    const validatePublicTitle = (value: string | null): string | undefined => {
+        const trimmedValue = value?.trim() ?? '';
+
+        if (!isStringNotNullOrEmpty(trimmedValue)) {
+            return 'Bitte geben Sie eine öffentliche Bezeichnung für den Prozess an.';
+        }
+
+        if (trimmedValue.length < 3) {
+            return 'Die öffentliche Bezeichnung des Prozesses muss mindestens 3 Zeichen lang sein.';
+        }
+
+        if (trimmedValue.length > 96) {
+            return 'Die öffentliche Bezeichnung des Prozesses darf maximal 96 Zeichen lang sein.';
+        }
+
+        return undefined;
+    };
+
     const validateDepartment = (value: number | null): string | undefined => {
         if (value == null) {
             return 'Bitte wählen Sie eine Organisationseinheit aus.';
@@ -218,20 +264,98 @@ export function NewProcessDialog(props: NewProcessDialogProps): ReactNode {
         return undefined;
     };
 
-    const validateProcessConfiguration = (): boolean => {
+    const checkSlugAvailability = async (slug: string | null): Promise<boolean> => {
+        const slugFormatError = validateProcessSlug(slug);
+        if (slugFormatError != null || slug == null) {
+            return false;
+        }
+
+        setIsCheckingSlugAvailability(true);
+        try {
+            const isAvailable = await new ProcessDefinitionApiService()
+                .checkSlugAvailability(slug);
+
+            const nextAvailabilityError = isAvailable ? undefined : 'Dieser URL-Namespace ist bereits vergeben.';
+            setSlugAvailabilityError(nextAvailabilityError);
+            return isAvailable;
+        } catch (error) {
+            setSlugAvailabilityError('Die Verfügbarkeit des URL-Namespace konnte nicht geprüft werden.');
+            dispatch(showApiErrorSnackbar(error, 'Die Verfügbarkeit des URL-Namespace konnte nicht geprüft werden.'));
+            return false;
+        } finally {
+            setIsCheckingSlugAvailability(false);
+        }
+    };
+
+    const validateProcessConfiguration = async (): Promise<boolean> => {
         const nextNameError = validateName(nameOverride);
+        const nextPublicTitleError = validatePublicTitle(publicTitleOverride);
+        const nextSlugError = validateProcessSlug(slugOverride);
         const nextDepartmentError = validateDepartment(departmentOverride);
 
         setNameError(nextNameError);
+        setPublicTitleError(nextPublicTitleError);
+        setSlugError(nextSlugError);
         setDepartmentError(nextDepartmentError);
 
-        return nextNameError == null && nextDepartmentError == null;
+        if (nextNameError != null || nextPublicTitleError != null || nextSlugError != null || nextDepartmentError != null) {
+            return false;
+        }
+
+        return checkSlugAvailability(slugOverride);
     };
 
+    useEffect(() => {
+        const slugFormatError = validateProcessSlug(slugOverride);
+        setSlugAvailabilityError(undefined);
+
+        if (slugOverride == null || slugFormatError != null) {
+            setIsCheckingSlugAvailability(false);
+            return;
+        }
+
+        let cancelled = false;
+        setIsCheckingSlugAvailability(true);
+
+        const timeoutId = window.setTimeout(() => {
+            new ProcessDefinitionApiService()
+                .checkSlugAvailability(slugOverride)
+                .then((isAvailable) => {
+                    if (!cancelled) {
+                        setSlugAvailabilityError(isAvailable ? undefined : 'Dieser URL-Namespace ist bereits vergeben.');
+                    }
+                })
+                .catch((error) => {
+                    if (!cancelled) {
+                        setSlugAvailabilityError('Die Verfügbarkeit des URL-Namespace konnte nicht geprüft werden.');
+                        dispatch(showApiErrorSnackbar(error, 'Die Verfügbarkeit des URL-Namespace konnte nicht geprüft werden.'));
+                    }
+                })
+                .finally(() => {
+                    if (!cancelled) {
+                        setIsCheckingSlugAvailability(false);
+                    }
+                });
+        }, 500);
+
+        return () => {
+            cancelled = true;
+            window.clearTimeout(timeoutId);
+        };
+    }, [dispatch, slugOverride]);
+
     const handleSelectStartPoint = (templateData: ProcessExport, startPoint: SelectedStartPoint): void => {
+        const defaultPublicTitle = startPoint.type === 'empty' || !isStringNotNullOrEmpty(templateData.version.publicTitle) ? null : templateData.version.publicTitle;
+
         setSelectedTemplateData(templateData);
         setSelectedStartPoint(startPoint);
+        setPublicTitleOverride(defaultPublicTitle);
+        setPublicTitleManuallyEdited(isStringNotNullOrEmpty(defaultPublicTitle));
         setNameError(undefined);
+        setPublicTitleError(undefined);
+        setSlugError(undefined);
+        setSlugAvailabilityError(undefined);
+        setSlugManuallyEdited(false);
         setDepartmentError(undefined);
         setActiveStep(1);
     };
@@ -241,10 +365,16 @@ export function NewProcessDialog(props: NewProcessDialogProps): ReactNode {
         setSelectedTemplateData(null);
         setSelectedStartPoint(null);
         setNameOverride(null);
+        setPublicTitleOverride(null);
+        setPublicTitleManuallyEdited(false);
+        setSlugOverride(null);
+        setSlugManuallyEdited(false);
         setDepartmentOverride(null);
         setNameError(undefined);
+        setPublicTitleError(undefined);
+        setSlugError(undefined);
+        setSlugAvailabilityError(undefined);
         setDepartmentError(undefined);
-        setShowDepartmentDialog(false);
     };
 
     const handleClose = (): void => {
@@ -286,21 +416,23 @@ export function NewProcessDialog(props: NewProcessDialogProps): ReactNode {
             });
     };
 
-    const handleSave = (): void => {
+    const handleSave = async (): Promise<void> => {
         if (selectedTemplateData == null) {
             return;
         }
 
-        if (!validateProcessConfiguration()) {
+        if (!await validateProcessConfiguration()) {
             setActiveStep(1);
             return;
         }
 
-        if (nameOverride == null || departmentOverride == null) {
+        if (nameOverride == null || publicTitleOverride == null || slugOverride == null || departmentOverride == null) {
             return;
         }
 
         const processName = nameOverride.trim();
+        const publicTitle = publicTitleOverride.trim();
+        const processSlug = slugOverride.trim();
 
         setIsLoading(true);
 
@@ -310,6 +442,11 @@ export function NewProcessDialog(props: NewProcessDialogProps): ReactNode {
                 ...selectedTemplateData.process,
                 internalTitle: processName,
                 departmentId: departmentOverride,
+                slug: processSlug,
+            },
+            version: {
+                ...selectedTemplateData.version,
+                publicTitle,
             },
         };
 
@@ -533,26 +670,115 @@ export function NewProcessDialog(props: NewProcessDialogProps): ReactNode {
                                     label="Name des Prozesses (intern)"
                                     value={nameOverride}
                                     onChange={(val) => {
-                                        setNameOverride(val ?? null);
+                                        const nextName = val ?? null;
+                                        setNameOverride(nextName);
+                                        setNameError(undefined);
+
+                                        if (!publicTitleManuallyEdited) {
+                                            setPublicTitleOverride(nextName);
+                                            setPublicTitleError(undefined);
+                                        }
+
+                                        if (!slugManuallyEdited) {
+                                            // Keep the URL namespace in sync until the user enters a custom value.
+                                            setSlugOverride(normalizeProcessSlugInput(nextName));
+                                            setSlugError(undefined);
+                                            setSlugAvailabilityError(undefined);
+                                        }
                                     }}
                                     required={true}
                                     disabled={isLoading}
                                     error={nameError}
                                     minCharacters={3}
                                     maxCharacters={96}
+                                    hint="Nur intern sichtbar; dient zur Wiedererkennung des Prozesses in der Verwaltung."
+                                />
+
+                                <TextFieldComponent
+                                    label="Öffentliche Bezeichnung"
+                                    value={publicTitleOverride}
+                                    onChange={(val) => {
+                                        const nextPublicTitle = val ?? null;
+                                        setPublicTitleOverride(nextPublicTitle);
+                                        setPublicTitleManuallyEdited(nextPublicTitle != null && nextPublicTitle.length > 0);
+                                        setPublicTitleError(undefined);
+                                    }}
+                                    required={true}
+                                    disabled={isLoading}
+                                    error={publicTitleError}
+                                    minCharacters={3}
+                                    maxCharacters={96}
+                                    hint="Wird öffentlich im Kontext der Prozessversion verwendet (z. B. im Self-Service-Portal)."
+                                    sx={{
+                                        mt: 2,
+                                    }}
+                                />
+
+                                <TextFieldComponent
+                                    label="URL-Namespace des Prozesses"
+                                    value={slugOverride}
+                                    onChange={(val) => {
+                                        const nextSlug = normalizeProcessSlugInput(val);
+                                        setSlugOverride(nextSlug);
+                                        setSlugManuallyEdited(nextSlug != null && nextSlug.length > 0);
+                                        setSlugError(undefined);
+                                        setSlugAvailabilityError(undefined);
+                                    }}
+                                    required={true}
+                                    disabled={isLoading}
+                                    error={slugError ?? slugAvailabilityError}
+                                    minCharacters={3}
+                                    maxCharacters={PROCESS_SLUG_MAX_LENGTH}
+                                    hint="Der Namespace steht in öffentlichen URLs zwischen Elementtyp und Element-Slug, z. B. /form/hundesteuer/antrag."
+                                    pattern={{
+                                        regex: '^[a-z0-9-]+$',
+                                        message: 'Der URL-Namespace darf nur aus Kleinbuchstaben, Zahlen und Bindestrichen bestehen.',
+                                    }}
+                                    muiPassTroughProps={{
+                                        InputProps: {
+                                            startAdornment: (
+                                                <InputAdornment position="start" sx={{whiteSpace: 'nowrap', flexShrink: 0}}>
+                                                    <Box component="span" sx={{whiteSpace: 'nowrap'}}>
+                                                        /element-typ/
+                                                    </Box>
+                                                </InputAdornment>
+                                            ),
+                                            endAdornment: (
+                                                <InputAdornment position="end" sx={{whiteSpace: 'nowrap', flexShrink: 0}}>
+                                                    <Box
+                                                        component="span"
+                                                        sx={{
+                                                            display: 'inline-flex',
+                                                            alignItems: 'center',
+                                                            gap: 0.75,
+                                                            whiteSpace: 'nowrap',
+                                                        }}
+                                                    >
+                                                        {
+                                                            isCheckingSlugAvailability &&
+                                                            <CircularProgress size={16} color="inherit"/>
+                                                        }
+                                                        /element-slug
+                                                    </Box>
+                                                </InputAdornment>
+                                            ),
+                                        },
+                                    }}
+                                    sx={{
+                                        mt: 2,
+                                    }}
                                 />
 
                                 <DepartmentSelectField
                                     label="Verwaltende Organisationseinheit"
                                     value={selectedDepartment}
-                                    onOpenDialog={() => {
-                                        setShowDepartmentDialog(true);
-                                    }}
-                                    onClear={() => {
-                                        setDepartmentOverride(null);
+                                    departments={availableDepartments}
+                                    dialogTitle="Organisationseinheit auswählen"
+                                    onChange={(department) => {
+                                        setDepartmentOverride(department?.id ?? null);
                                         setDepartmentError(undefined);
                                     }}
-                                    disabled={isLoading}
+                                    disabled={isLoading || availableDepartments == null}
                                     error={departmentError}
                                     required={true}
                                     hint="Die ausgewählte Einheit wird als verantwortlich für diesen Prozess festgelegt und kann z. B. Berechtigungen verwalten."
@@ -579,12 +805,13 @@ export function NewProcessDialog(props: NewProcessDialogProps): ReactNode {
 
                                 <Button
                                     onClick={() => {
-                                        if (!validateProcessConfiguration()) {
-                                            return;
-                                        }
-
-                                        setActiveStep(2);
+                                        void validateProcessConfiguration().then((isValid) => {
+                                            if (isValid) {
+                                                setActiveStep(2);
+                                            }
+                                        });
                                     }}
+                                    disabled={isLoading || isCheckingSlugAvailability}
                                     endIcon={<ArrowForward/>}
                                     variant="contained"
                                 >
@@ -641,10 +868,10 @@ export function NewProcessDialog(props: NewProcessDialogProps): ReactNode {
 
                                 <Button
                                     onClick={() => {
-                                        handleSave();
+                                        void handleSave();
                                     }}
                                     endIcon={<Save/>}
-                                    disabled={isLoading}
+                                    disabled={isLoading || isCheckingSlugAvailability}
                                     variant="contained"
                                 >
                                     Anlegen und Bearbeiten
@@ -656,84 +883,7 @@ export function NewProcessDialog(props: NewProcessDialogProps): ReactNode {
                 </DialogContent>
             </Dialog>
 
-            <DepartmentSelectionDialog
-                open={showDepartmentDialog}
-                departments={availableDepartments}
-                selectedDepartmentId={departmentOverride}
-                onClose={() => {
-                    setShowDepartmentDialog(false);
-                }}
-                onSelect={(department) => {
-                    setDepartmentOverride(department.id);
-                    setDepartmentError(undefined);
-                    setShowDepartmentDialog(false);
-                }}
-            />
         </>
-    );
-}
-
-interface DepartmentSelectionDialogProps {
-    open: boolean;
-    departments?: VDepartmentShadowedEntityWithChildren[];
-    selectedDepartmentId: number | null;
-    onClose: () => void;
-    onSelect: (department: VDepartmentShadowedEntityWithChildren) => void;
-}
-
-function DepartmentSelectionDialog(props: DepartmentSelectionDialogProps): ReactNode {
-    const {
-        open,
-        departments,
-        selectedDepartmentId,
-        onClose,
-        onSelect,
-    } = props;
-
-    return (
-        <Dialog
-            open={open}
-            onClose={onClose}
-            fullWidth
-            maxWidth="lg"
-        >
-            <DialogTitleWithClose onClose={onClose}>
-                Organisationseinheit auswählen
-            </DialogTitleWithClose>
-
-            <DialogContent
-                sx={{
-                    p: 2,
-                    height: 'min(74vh, 820px)',
-                    overflowY: 'auto',
-                }}
-            >
-                <DepartmentBrowser
-                    departments={departments}
-                    selectedDepartmentId={selectedDepartmentId}
-                    searchLabel="Organisationseinheit suchen"
-                    searchPlaceholder="Name, Adresse oder Typ suchen…"
-                    emptyState={(
-                        <AlertComponent
-                            color="info"
-                            sx={{my: 1}}
-                        >
-                            Es sind keine Organisationseinheiten verfügbar.
-                        </AlertComponent>
-                    )}
-                    getActions={(department) => [
-                        {
-                            label: 'Auswählen',
-                            icon: <Check />,
-                            variant: 'contained',
-                            onClick: () => {
-                                onSelect(department);
-                            },
-                        },
-                    ]}
-                />
-            </DialogContent>
-        </Dialog>
     );
 }
 
@@ -983,6 +1133,7 @@ const EmptyProcess: ProcessExport = {
         internalTitle: 'Neuer Prozess',
         departmentId: 0,
         accessKey: '',
+        slug: '',
         versionCount: 0,
         draftedVersion: null,
         publishedVersion: null,

--- a/app/src/modules/process/dialogs/process-settings-dialog/process-settings-dialog-general-tab.tsx
+++ b/app/src/modules/process/dialogs/process-settings-dialog/process-settings-dialog-general-tab.tsx
@@ -1,0 +1,404 @@
+import React, {forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useState} from 'react';
+import {Box, Button, CircularProgress, InputAdornment, Stack, TextField} from '@mui/material';
+import History from '@aivot/mui-material-symbols-400-outlined/dist/history/History';
+import MoveGroup from '@aivot/mui-material-symbols-400-outlined/dist/move-group/MoveGroup';
+import {ProcessEntity} from '../../entities/process-entity';
+import {ProcessDefinitionApiService} from '../../services/process-definition-api-service';
+import {useAppDispatch} from '../../../../hooks/use-app-dispatch';
+import {showApiErrorSnackbar, showSuccessSnackbar} from '../../../../slices/snackbar-slice';
+import {deepEquals} from '../../../../utils/equality-utils';
+import {ProcessSettingsDialogSlugHistoryDialog} from './process-settings-dialog-slug-history-dialog';
+import {normalizeProcessSlugInput, PROCESS_SLUG_MAX_LENGTH, validateProcessSlug} from '../../utils/process-slug-utils';
+import {ElementEditorSectionHeader} from '../../../../components/element-editor-section-header/element-editor-section-header';
+import {VDepartmentShadowedEntity} from '../../../departments/entities/v-department-shadowed-entity';
+import {MoveProcessToDepartmentDialog} from '../move-process-to-department-dialog';
+import {DepartmentSelectField} from '../../../departments/components/department-select-field';
+
+interface ProcessSettingsDialogGeneralTabProps {
+    open: boolean;
+    process: ProcessEntity;
+    departments: VDepartmentShadowedEntity[];
+    onProcessChange: (process: ProcessEntity) => void;
+    onUnsavedChangesChange?: (hasUnsavedChanges: boolean) => void;
+    onSavingChange?: (isSaving: boolean) => void;
+    onValidationErrorChange?: (hasValidationError: boolean) => void;
+}
+
+export interface ProcessSettingsDialogGeneralTabHandle {
+    save: () => void;
+}
+
+export const ProcessSettingsDialogGeneralTab = forwardRef<ProcessSettingsDialogGeneralTabHandle, ProcessSettingsDialogGeneralTabProps>(function ProcessSettingsDialogGeneralTab(props, ref) {
+    const dispatch = useAppDispatch();
+
+    const {
+        open,
+        process,
+        departments,
+        onProcessChange,
+        onUnsavedChangesChange,
+        onSavingChange,
+        onValidationErrorChange,
+    } = props;
+
+    const [draft, setDraft] = useState<ProcessEntity>(process);
+    const [isSaving, setIsSaving] = useState(false);
+    const [slugAvailabilityError, setSlugAvailabilityError] = useState<string | undefined>();
+    const [isCheckingSlugAvailability, setIsCheckingSlugAvailability] = useState(false);
+    const [showSlugHistoryDialog, setShowSlugHistoryDialog] = useState(false);
+    const [showMoveDialog, setShowMoveDialog] = useState(false);
+
+    useEffect(() => {
+        if (open) {
+            setDraft(process);
+        }
+    }, [open, process]);
+
+    const hasUnsavedChanges = useMemo(() => {
+        return !deepEquals(
+            {
+                internalTitle: process.internalTitle,
+                slug: process.slug,
+            },
+            {
+                internalTitle: draft.internalTitle,
+                slug: draft.slug,
+            },
+        );
+    }, [draft.internalTitle, draft.slug, process.internalTitle, process.slug]);
+
+    const internalTitleError = useMemo(() => {
+        const title = draft.internalTitle.trim();
+
+        if (title.length === 0) {
+            return 'Bitte geben Sie einen internen Titel an.';
+        }
+
+        if (title.length < 3) {
+            return 'Der interne Titel muss mindestens 3 Zeichen lang sein.';
+        }
+
+        if (title.length > 96) {
+            return 'Der interne Titel darf maximal 96 Zeichen lang sein.';
+        }
+
+        return undefined;
+    }, [draft.internalTitle]);
+
+    useEffect(() => {
+        onUnsavedChangesChange?.(hasUnsavedChanges);
+    }, [hasUnsavedChanges, onUnsavedChangesChange]);
+
+    useEffect(() => {
+        return () => {
+            onUnsavedChangesChange?.(false);
+        };
+    }, [onUnsavedChangesChange]);
+
+    useEffect(() => {
+        onSavingChange?.(isSaving);
+    }, [isSaving, onSavingChange]);
+
+    useEffect(() => {
+        return () => {
+            onSavingChange?.(false);
+        };
+    }, [onSavingChange]);
+
+    const slugFormatError = useMemo(() => {
+        return validateProcessSlug(draft.slug);
+    }, [draft.slug]);
+    const slugError = slugFormatError ?? slugAvailabilityError;
+
+    const managingDepartment = useMemo(() => {
+        return departments.find((department) => department.id === process.departmentId);
+    }, [departments, process.departmentId]);
+
+    useEffect(() => {
+        onValidationErrorChange?.(internalTitleError != null || slugError != null || isCheckingSlugAvailability);
+    }, [internalTitleError, isCheckingSlugAvailability, onValidationErrorChange, slugError]);
+
+    useEffect(() => {
+        return () => {
+            onValidationErrorChange?.(false);
+        };
+    }, [onValidationErrorChange]);
+
+    useEffect(() => {
+        setSlugAvailabilityError(undefined);
+
+        if (draft.slug === process.slug || slugFormatError != null) {
+            setIsCheckingSlugAvailability(false);
+            return;
+        }
+
+        let cancelled = false;
+        setIsCheckingSlugAvailability(true);
+
+        const timeoutId = window.setTimeout(() => {
+            new ProcessDefinitionApiService()
+                .checkSlugAvailability(draft.slug, process.id)
+                .then((isAvailable) => {
+                    if (!cancelled) {
+                        setSlugAvailabilityError(isAvailable ? undefined : 'Dieser URL-Namespace ist bereits vergeben.');
+                    }
+                })
+                .catch((error) => {
+                    if (!cancelled) {
+                        setSlugAvailabilityError('Die Verfügbarkeit des URL-Namespace konnte nicht geprüft werden.');
+                        dispatch(showApiErrorSnackbar(error, 'Die Verfügbarkeit des URL-Namespace konnte nicht geprüft werden.'));
+                    }
+                })
+                .finally(() => {
+                    if (!cancelled) {
+                        setIsCheckingSlugAvailability(false);
+                    }
+                });
+        }, 500);
+
+        return () => {
+            cancelled = true;
+            window.clearTimeout(timeoutId);
+        };
+    }, [dispatch, draft.slug, process.id, process.slug, slugFormatError]);
+
+    const handleSave = useCallback(() => {
+        if (!hasUnsavedChanges || isSaving || internalTitleError != null || slugError != null || isCheckingSlugAvailability) {
+            return;
+        }
+
+        setIsSaving(true);
+
+        new ProcessDefinitionApiService()
+            .update(process.id, {
+                ...process,
+                internalTitle: draft.internalTitle.trim(),
+                slug: draft.slug,
+            })
+            .then((updatedProcess) => {
+                onProcessChange(updatedProcess);
+                setDraft(updatedProcess);
+                dispatch(showSuccessSnackbar('Die Prozesseinstellungen wurden gespeichert.'));
+            })
+            .catch((error) => {
+                dispatch(showApiErrorSnackbar(error, 'Die Prozesseinstellungen konnten nicht gespeichert werden.'));
+            })
+            .finally(() => {
+                setIsSaving(false);
+            });
+    }, [dispatch, draft.internalTitle, draft.slug, hasUnsavedChanges, internalTitleError, isCheckingSlugAvailability, isSaving, onProcessChange, process, slugError]);
+
+    useImperativeHandle(ref, () => ({
+        save: handleSave,
+    }), [handleSave]);
+
+    return (
+        <>
+            <Stack spacing={3}>
+                <ElementEditorSectionHeader
+                    title="Allgemeine Einstellungen"
+                    variant="h5"
+                    disableMarginTop
+                >
+                    Diese Einstellungen gelten versionsunabhängig für den gesamten Prozess. Legen Sie fest, wie der Prozess intern bezeichnet wird und über welchen URL-Namespace seine öffentlichen Einstiegspunkte erreichbar sind.
+                </ElementEditorSectionHeader>
+
+                <TextField
+                    label="Interner Titel"
+                    value={draft.internalTitle}
+                    onChange={(event) => {
+                        setDraft({
+                            ...draft,
+                            internalTitle: event.target.value,
+                        });
+                    }}
+                    fullWidth
+                    required
+                    error={internalTitleError != null}
+                    helperText={internalTitleError ?? 'Nur intern sichtbar; dient zur Wiedererkennung des Prozesses in der Verwaltung.'}
+                    inputProps={{
+                        maxLength: 96,
+                    }}
+                />
+
+                <Box
+                    sx={{
+                        display: 'flex',
+                        flexDirection: {
+                            xs: 'column',
+                            sm: 'row',
+                        },
+                        alignItems: {
+                            xs: 'stretch',
+                            sm: 'flex-start',
+                        },
+                        gap: 2,
+                    }}
+                >
+                    <Box
+                        sx={{
+                            flex: 1,
+                            minWidth: 0,
+                        }}
+                    >
+                        <TextField
+                            label="URL-Namespace des Prozesses"
+                            value={draft.slug}
+                            onChange={(event) => {
+                                const nextSlug = normalizeProcessSlugInput(event.target.value) ?? '';
+                                setDraft({
+                                    ...draft,
+                                    slug: nextSlug,
+                                });
+                                setSlugAvailabilityError(undefined);
+                            }}
+                            fullWidth
+                            required
+                            error={slugError != null}
+                            helperText={slugError ?? 'Wenn Sie den Namespace ändern, wird der bisherige Namespace automatisch umgeleitet, bis Sie die Historie leeren.'}
+                            inputProps={{
+                                maxLength: PROCESS_SLUG_MAX_LENGTH,
+                                pattern: '^[a-z0-9-]+$',
+                            }}
+                            InputProps={{
+                                startAdornment: (
+                                    <InputAdornment position="start" sx={{whiteSpace: 'nowrap', flexShrink: 0}}>
+                                        <Box component="span" sx={{whiteSpace: 'nowrap'}}>
+                                            /element-typ/
+                                        </Box>
+                                    </InputAdornment>
+                                ),
+                                endAdornment: (
+                                    <InputAdornment position="end" sx={{whiteSpace: 'nowrap', flexShrink: 0}}>
+                                        <Box
+                                            component="span"
+                                            sx={{
+                                                display: 'inline-flex',
+                                                alignItems: 'center',
+                                                gap: 0.75,
+                                                whiteSpace: 'nowrap',
+                                            }}
+                                        >
+                                            {
+                                                isCheckingSlugAvailability &&
+                                                <CircularProgress size={16} color="inherit"/>
+                                            }
+                                            /element-slug
+                                        </Box>
+                                    </InputAdornment>
+                                ),
+                            }}
+                        />
+                    </Box>
+
+                    <Button
+                        variant="outlined"
+                        startIcon={<History/>}
+                        onClick={() => {
+                            setShowSlugHistoryDialog(true);
+                        }}
+                        sx={{
+                            mt: 3,
+                            alignSelf: {
+                                xs: 'stretch',
+                                sm: 'flex-start',
+                            },
+                            whiteSpace: 'nowrap',
+                        }}
+                    >
+                        URL-Namespace-Historie anzeigen
+                    </Button>
+                </Box>
+
+                <ElementEditorSectionHeader
+                    title="Verwaltende Organisationseinheit"
+                    variant="h6"
+                    disableMarginBottom
+                >
+                    Die verwaltende Organisationseinheit ist für diesen Prozess zuständig und bildet die Grundlage für prozessbezogene Berechtigungen.
+                </ElementEditorSectionHeader>
+
+                <Box
+                    sx={{
+                        display: 'flex',
+                        flexDirection: {
+                            xs: 'column',
+                            sm: 'row',
+                        },
+                        alignItems: {
+                            xs: 'stretch',
+                            sm: 'flex-start',
+                        },
+                        gap: 2,
+                    }}
+                >
+                    <Box
+                        sx={{
+                            flex: 1,
+                            minWidth: 0,
+                        }}
+                    >
+                        <DepartmentSelectField
+                            label="Aktuell verwaltende Organisationseinheit"
+                            value={managingDepartment ?? null}
+                            onChange={() => undefined}
+                            disabled
+                            placeholder={
+                                departments.length === 0
+                                    ? 'Organisationseinheit wird geladen...'
+                                    : `Unbekannte Organisationseinheit (${process.departmentId})`
+                            }
+                            hint={
+                                'Versionsunabhängig. Eine Übertragung kann die Sichtbarkeit des Prozesses und Ihre eigenen Berechtigungen verändern.' +
+                                (hasUnsavedChanges ? ' Speichern Sie zuerst die allgemeinen Einstellungen.' : '')
+                            }
+                        />
+                    </Box>
+
+                    <Button
+                        variant="outlined"
+                        startIcon={<MoveGroup/>}
+                        disabled={hasUnsavedChanges || isSaving}
+                        onClick={() => {
+                            // Moving the process changes its permission boundary, so keep it separate from unsaved metadata edits.
+                            setShowMoveDialog(true);
+                        }}
+                        sx={{
+                            mt: 3,
+                            alignSelf: {
+                                xs: 'stretch',
+                                sm: 'flex-start',
+                            },
+                            whiteSpace: 'nowrap',
+                        }}
+                    >
+                        Prozess übertragen
+                    </Button>
+                </Box>
+            </Stack>
+
+            <ProcessSettingsDialogSlugHistoryDialog
+                open={showSlugHistoryDialog}
+                process={process}
+                onClose={() => {
+                    setShowSlugHistoryDialog(false);
+                }}
+            />
+
+            {
+                showMoveDialog &&
+                <MoveProcessToDepartmentDialog
+                    processId={process.id}
+                    onClose={() => {
+                        setShowMoveDialog(false);
+                    }}
+                    onMoved={(updatedProcess) => {
+                        setShowMoveDialog(false);
+                        setDraft(updatedProcess);
+                        onProcessChange(updatedProcess);
+                    }}
+                />
+            }
+        </>
+    );
+});

--- a/app/src/modules/process/dialogs/process-settings-dialog/process-settings-dialog-process-access-tab.tsx
+++ b/app/src/modules/process/dialogs/process-settings-dialog/process-settings-dialog-process-access-tab.tsx
@@ -29,6 +29,7 @@ import Add from '@aivot/mui-material-symbols-400-outlined/dist/add/Add';
 import Delete from '@aivot/mui-material-symbols-400-outlined/dist/delete/Delete';
 import Save from '@aivot/mui-material-symbols-400-outlined/dist/save/Save';
 import {deepEquals} from '../../../../utils/equality-utils';
+import {ElementEditorSectionHeader} from '../../../../components/element-editor-section-header/element-editor-section-header';
 
 interface ProcessSettingsDialogTabProps {
     open: boolean;
@@ -386,6 +387,15 @@ export function ProcessSettingsDialogProcessAccessTab(props: ProcessSettingsDial
 
     return (
         <>
+            <ElementEditorSectionHeader
+                title="Berechtigungen des Prozesses"
+                variant="h5"
+                disableMarginTop
+                maxWidth={560}
+            >
+                Steuern Sie, welche Organisationseinheiten und Teams diesen Prozess in der Verwaltung sehen, bearbeiten, prüfen oder veröffentlichen dürfen.
+            </ElementEditorSectionHeader>
+
             <TableContainer>
                 <Table size="small">
                     <TableHead>

--- a/app/src/modules/process/dialogs/process-settings-dialog/process-settings-dialog-process-instance-access-preset-tab.tsx
+++ b/app/src/modules/process/dialogs/process-settings-dialog/process-settings-dialog-process-instance-access-preset-tab.tsx
@@ -31,6 +31,7 @@ import {ProcessInstanceAccessControlPresetEntity} from '../../entities/process-i
 import {ProcessInstanceAccessControlPresetApiService} from '../../services/process-instance-access-control-preset-api-service';
 import {ProcessVersionEntity} from '../../entities/process-version-entity';
 import {deepEquals} from '../../../../utils/equality-utils';
+import {ElementEditorSectionHeader} from '../../../../components/element-editor-section-header/element-editor-section-header';
 
 interface ProcessSettingsDialogTabProps {
     open: boolean;
@@ -404,6 +405,15 @@ export function ProcessSettingsDialogProcessInstanceAccessPresetTab(props: Proce
 
     return (
         <>
+            <ElementEditorSectionHeader
+                title="Berechtigungen für neue Vorgänge"
+                variant="h5"
+                disableMarginTop
+                maxWidth={560}
+            >
+                Legen Sie fest, welche Organisationseinheiten und Teams bei neu erstellten Vorgängen standardmäßig Zugriff erhalten.
+            </ElementEditorSectionHeader>
+
             <TableContainer>
                 <Table size="small">
                     <TableHead>

--- a/app/src/modules/process/dialogs/process-settings-dialog/process-settings-dialog-slug-history-dialog.tsx
+++ b/app/src/modules/process/dialogs/process-settings-dialog/process-settings-dialog-slug-history-dialog.tsx
@@ -1,0 +1,185 @@
+import {useCallback, useEffect, useState} from 'react';
+import {Alert, Button, Dialog, DialogActions, DialogContent, List, ListItem, ListItemIcon, ListItemText, Skeleton, Typography} from '@mui/material';
+import Delete from '@aivot/mui-material-symbols-400-outlined/dist/delete/Delete';
+import LinkIcon from '@aivot/mui-material-symbols-400-outlined/dist/link/Link';
+import {DialogTitleWithClose} from '../../../../components/dialog-title-with-close/dialog-title-with-close';
+import {ProcessEntity} from '../../entities/process-entity';
+import {ProcessSlugHistoryEntity} from '../../entities/process-slug-history-entity';
+import {ProcessDefinitionApiService} from '../../services/process-definition-api-service';
+import {useAppDispatch} from '../../../../hooks/use-app-dispatch';
+import {showApiErrorSnackbar, showSuccessSnackbar} from '../../../../slices/snackbar-slice';
+import {useConfirm} from '../../../../providers/confirm-provider';
+
+interface ProcessSettingsDialogSlugHistoryDialogProps {
+    open: boolean;
+    process: ProcessEntity;
+    onClose: () => void;
+}
+
+export function ProcessSettingsDialogSlugHistoryDialog(props: ProcessSettingsDialogSlugHistoryDialogProps) {
+    const dispatch = useAppDispatch();
+    const confirm = useConfirm();
+
+    const {
+        open,
+        process,
+        onClose,
+    } = props;
+
+    const [slugHistory, setSlugHistory] = useState<ProcessSlugHistoryEntity[]>([]);
+    const [isLoading, setIsLoading] = useState(false);
+    const [isClearing, setIsClearing] = useState(false);
+
+    const loadSlugHistory = useCallback(() => {
+        setIsLoading(true);
+        new ProcessDefinitionApiService()
+            .listSlugHistory(process.id)
+            .then(setSlugHistory)
+            .catch((error) => {
+                dispatch(showApiErrorSnackbar(error, 'Die URL-Namespace-Historie konnte nicht geladen werden.'));
+            })
+            .finally(() => {
+                setIsLoading(false);
+            });
+    }, [dispatch, process.id]);
+
+    useEffect(() => {
+        if (open) {
+            loadSlugHistory();
+        }
+    }, [loadSlugHistory, open]);
+
+    const handleClear = async () => {
+        if (slugHistory.length === 0 || isClearing) {
+            return;
+        }
+
+        const confirmed = await confirm({
+            title: 'URL-Namespace-Historie leeren',
+            confirmButtonText: 'Historie leeren',
+            isDestructive: true,
+            children: (
+                <Typography>
+                    Möchten Sie alle früheren URL-Namespaces dieses Prozesses wirklich löschen?
+                    Diese Namespaces können danach von anderen Prozessen verwendet werden.
+                </Typography>
+            ),
+        });
+
+        if (!confirmed) {
+            return;
+        }
+
+        setIsClearing(true);
+        // Clearing history releases old namespaces; the current process slug is never deleted here.
+        new ProcessDefinitionApiService()
+            .clearSlugHistory(process.id)
+            .then(() => {
+                setSlugHistory([]);
+                dispatch(showSuccessSnackbar('Die URL-Namespace-Historie wurde geleert.'));
+            })
+            .catch((error) => {
+                dispatch(showApiErrorSnackbar(error, 'Die URL-Namespace-Historie konnte nicht geleert werden.'));
+            })
+            .finally(() => {
+                setIsClearing(false);
+            });
+    };
+
+    return (
+        <Dialog
+            open={open}
+            onClose={onClose}
+            fullWidth
+            maxWidth="sm"
+        >
+            <DialogTitleWithClose onClose={onClose}>
+                URL-Namespace-Historie
+            </DialogTitleWithClose>
+            <DialogContent>
+                <Typography variant="body2" color="text.secondary" sx={{mb: 2}}>
+                    Die Historie enthält frühere URL-Namespaces des Prozesses. Alte Namespaces werden automatisch auf den aktuellen
+                    Namespace umgeleitet, bis Sie die Historie leeren.
+                </Typography>
+
+                {
+                    isLoading &&
+                    <Skeleton height={96}/>
+                }
+
+                {
+                    !isLoading && slugHistory.length === 0 &&
+                    <Alert severity="info">
+                        Für diesen Prozess sind keine früheren URL-Namespaces gespeichert.
+                    </Alert>
+                }
+
+                {
+                    !isLoading && slugHistory.length > 0 &&
+                    <>
+                        <Alert severity="warning" sx={{mb: 2}}>
+                            Beim Leeren werden diese Namespaces freigegeben und können anschließend von anderen Prozessen verwendet werden.
+                        </Alert>
+                        <List
+                            dense
+                            sx={{'& .MuiListItem-root:last-of-type': {borderBottom: 'none'}}}
+                        >
+                            {
+                                slugHistory.map((history) => (
+                                    <ListItem
+                                        key={history.slug}
+                                        sx={{
+                                            borderBottom: '1px solid #eee',
+                                            px: 0.25,
+                                        }}
+                                    >
+                                        <ListItemIcon sx={{color: 'primary.dark', minWidth: '2.5rem', textAlign: 'center'}}>
+                                            <LinkIcon/>
+                                        </ListItemIcon>
+                                        <ListItemText
+                                            primary={
+                                                <Typography component="code" variant="body2">
+                                                    /{history.slug}
+                                                </Typography>
+                                            }
+                                            secondary={`Leitet automatisch auf /${process.slug} um`}
+                                            slotProps={{
+                                                primary: {
+                                                    sx: {
+                                                        whiteSpace: 'nowrap',
+                                                        overflow: 'hidden',
+                                                        textOverflow: 'ellipsis',
+                                                    },
+                                                },
+                                            }}
+                                        />
+                                    </ListItem>
+                                ))
+                            }
+                        </List>
+                    </>
+                }
+            </DialogContent>
+            <DialogActions>
+                <Button
+                    variant="contained"
+                    color="error"
+                    startIcon={<Delete/>}
+                    disabled={slugHistory.length === 0 || isLoading || isClearing}
+                    onClick={() => {
+                        void handleClear();
+                    }}
+                >
+                    Historie leeren
+                </Button>
+                <div style={{flexGrow: 1}}/>
+                <Button
+                    onClick={onClose}
+                    disabled={isClearing}
+                >
+                    Schließen
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+}

--- a/app/src/modules/process/dialogs/process-settings-dialog/process-settings-dialog-version-tab.tsx
+++ b/app/src/modules/process/dialogs/process-settings-dialog/process-settings-dialog-version-tab.tsx
@@ -1,0 +1,256 @@
+import React, {forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useState} from 'react';
+import {Alert, Stack} from '@mui/material';
+import {ProcessVersionEntity} from '../../entities/process-version-entity';
+import {ElementEditorSectionHeader} from '../../../../components/element-editor-section-header/element-editor-section-header';
+import {TextFieldComponent} from '../../../../components/text-field/text-field-component';
+import {RadioFieldComponent} from '../../../../components/radio-field/radio-field-component';
+import {
+    CASE_NUMBER_TEMPLATE_MAX_LENGTH,
+    CASE_NUMBER_TYPE_TEMPLATE,
+    CASE_NUMBER_TYPE_UUID,
+    getCaseNumberType,
+    validateCaseNumberTemplate,
+} from '../../utils/process-case-number-utils';
+import {ProcessStatus} from '../../enums/process-status';
+import {deepEquals} from '../../../../utils/equality-utils';
+import {ProcessDefinitionVersionApiService} from '../../services/process-definition-version-api-service';
+import {useAppDispatch} from '../../../../hooks/use-app-dispatch';
+import {showApiErrorSnackbar, showSuccessSnackbar} from '../../../../slices/snackbar-slice';
+
+interface ProcessSettingsDialogVersionTabProps {
+    open: boolean;
+    version: ProcessVersionEntity;
+    onVersionChange: (version: ProcessVersionEntity) => void;
+    onUnsavedChangesChange?: (hasUnsavedChanges: boolean) => void;
+    onSavingChange?: (isSaving: boolean) => void;
+    onValidationErrorChange?: (hasValidationError: boolean) => void;
+}
+
+export interface ProcessSettingsDialogVersionTabHandle {
+    save: () => void;
+}
+
+const caseNumberTypeOptions = [
+    {
+        label: 'UUID',
+        subLabel: 'Erzeugt einen technischen UUID-Vorgangsschlüssel, z. B. 550e8400-e29b-41d4-a716-446655440000.',
+        value: CASE_NUMBER_TYPE_UUID,
+    },
+    {
+        label: 'Formatvorlage',
+        subLabel: 'Erzeugt fortlaufende Vorgangsschlüssel nach einem Muster, z. B. VG-%YYY-%I(6).',
+        value: CASE_NUMBER_TYPE_TEMPLATE,
+    },
+];
+
+export const ProcessSettingsDialogVersionTab = forwardRef<ProcessSettingsDialogVersionTabHandle, ProcessSettingsDialogVersionTabProps>(function ProcessSettingsDialogVersionTab(props, ref) {
+    const dispatch = useAppDispatch();
+
+    const {
+        open,
+        version,
+        onVersionChange,
+        onUnsavedChangesChange,
+        onSavingChange,
+        onValidationErrorChange,
+    } = props;
+
+    const [draft, setDraft] = useState<ProcessVersionEntity>(version);
+    const [isSaving, setIsSaving] = useState(false);
+
+    const isEditable = version.status === ProcessStatus.Drafted;
+    const caseNumberType = getCaseNumberType(draft.caseNumberTemplate);
+
+    useEffect(() => {
+        if (open) {
+            setDraft(version);
+        }
+    }, [open, version]);
+
+    const publicTitleError = useMemo(() => {
+        const title = draft.publicTitle.trim();
+
+        if (title.length === 0) {
+            return 'Bitte geben Sie eine öffentliche Bezeichnung an.';
+        }
+
+        if (title.length < 3) {
+            return 'Die öffentliche Bezeichnung muss mindestens 3 Zeichen lang sein.';
+        }
+
+        if (title.length > 96) {
+            return 'Die öffentliche Bezeichnung darf maximal 96 Zeichen lang sein.';
+        }
+
+        return undefined;
+    }, [draft.publicTitle]);
+
+    const caseNumberTemplateError = useMemo(() => {
+        if (caseNumberType !== CASE_NUMBER_TYPE_TEMPLATE) {
+            return undefined;
+        }
+
+        return validateCaseNumberTemplate(draft.caseNumberTemplate);
+    }, [caseNumberType, draft.caseNumberTemplate]);
+
+    const hasValidationError = publicTitleError != null || caseNumberTemplateError != null;
+
+    const hasUnsavedChanges = useMemo(() => {
+        return !deepEquals(
+            {
+                publicTitle: version.publicTitle,
+                caseNumberTemplate: version.caseNumberTemplate,
+            },
+            {
+                publicTitle: draft.publicTitle,
+                caseNumberTemplate: draft.caseNumberTemplate,
+            },
+        );
+    }, [draft.caseNumberTemplate, draft.publicTitle, version.caseNumberTemplate, version.publicTitle]);
+
+    useEffect(() => {
+        onUnsavedChangesChange?.(hasUnsavedChanges);
+    }, [hasUnsavedChanges, onUnsavedChangesChange]);
+
+    useEffect(() => {
+        return () => {
+            onUnsavedChangesChange?.(false);
+        };
+    }, [onUnsavedChangesChange]);
+
+    useEffect(() => {
+        onSavingChange?.(isSaving);
+    }, [isSaving, onSavingChange]);
+
+    useEffect(() => {
+        return () => {
+            onSavingChange?.(false);
+        };
+    }, [onSavingChange]);
+
+    useEffect(() => {
+        onValidationErrorChange?.(hasValidationError);
+    }, [hasValidationError, onValidationErrorChange]);
+
+    useEffect(() => {
+        return () => {
+            onValidationErrorChange?.(false);
+        };
+    }, [onValidationErrorChange]);
+
+    const handleSave = useCallback(() => {
+        if (!isEditable || !hasUnsavedChanges || isSaving || hasValidationError) {
+            return;
+        }
+
+        const nextVersion: ProcessVersionEntity = {
+            ...version,
+            publicTitle: draft.publicTitle.trim(),
+            caseNumberTemplate: caseNumberType === CASE_NUMBER_TYPE_TEMPLATE ? draft.caseNumberTemplate?.trim() ?? '' : null,
+        };
+
+        setIsSaving(true);
+
+        new ProcessDefinitionVersionApiService()
+            .update({
+                processDefinitionId: version.processId,
+                processDefinitionVersion: version.processVersion,
+            }, nextVersion)
+            .then((updatedVersion) => {
+                onVersionChange(updatedVersion);
+                setDraft(updatedVersion);
+                dispatch(showSuccessSnackbar('Die versionsspezifischen Einstellungen wurden gespeichert.'));
+            })
+            .catch((error) => {
+                dispatch(showApiErrorSnackbar(error, 'Die versionsspezifischen Einstellungen konnten nicht gespeichert werden.'));
+            })
+            .finally(() => {
+                setIsSaving(false);
+            });
+    }, [caseNumberType, dispatch, draft.caseNumberTemplate, draft.publicTitle, hasUnsavedChanges, hasValidationError, isEditable, isSaving, onVersionChange, version]);
+
+    useImperativeHandle(ref, () => ({
+        save: handleSave,
+    }), [handleSave]);
+
+    return (
+        <Stack spacing={3}>
+            <ElementEditorSectionHeader
+                title="Versionsspezifische Einstellungen"
+                variant="h5"
+                disableMarginTop
+                maxWidth={680}
+            >
+                Diese Angaben gelten nur für die aktuell geöffnete Prozessversion und werden erst wirksam, wenn diese Version veröffentlicht wird.
+            </ElementEditorSectionHeader>
+
+            {
+                !isEditable &&
+                <Alert severity="info">
+                    Versionsspezifische Einstellungen können nur in Entwurfsversionen geändert werden.
+                </Alert>
+            }
+
+            <TextFieldComponent
+                label="Öffentliche Bezeichnung"
+                value={draft.publicTitle}
+                onChange={(val) => {
+                    setDraft({
+                        ...draft,
+                        publicTitle: val ?? '',
+                    });
+                }}
+                required
+                disabled={!isEditable || isSaving}
+                error={publicTitleError}
+                minCharacters={3}
+                maxCharacters={96}
+                hint="Diese Bezeichnung wird öffentlich im Kontext der Prozessversion verwendet. Formulare können z. B. darauf zurückfallen, wenn der Formular-Knoten keine eigene öffentliche Bezeichnung hat."
+            />
+
+            <ElementEditorSectionHeader
+                title="Vorgangsschlüssel"
+                variant="h6"
+                disableMarginTop
+                disableMarginBottom
+                maxWidth={680}
+            >
+                Legen Sie fest, wie neue Vorgänge dieser Version einen Vorgangsschlüssel erhalten.
+            </ElementEditorSectionHeader>
+
+            <RadioFieldComponent
+                label="Vorgangsschlüssel-Typ"
+                value={caseNumberType}
+                onChange={(val) => {
+                    setDraft({
+                        ...draft,
+                        caseNumberTemplate: val === CASE_NUMBER_TYPE_TEMPLATE ? draft.caseNumberTemplate ?? '' : null,
+                    });
+                }}
+                options={caseNumberTypeOptions}
+                required
+                disabled={!isEditable || isSaving}
+            />
+
+            {
+                caseNumberType === CASE_NUMBER_TYPE_TEMPLATE &&
+                <TextFieldComponent
+                    label="Vorgangsschlüssel-Formatvorlage"
+                    value={draft.caseNumberTemplate}
+                    onChange={(val) => {
+                        setDraft({
+                            ...draft,
+                            caseNumberTemplate: val ?? '',
+                        });
+                    }}
+                    required
+                    disabled={!isEditable || isSaving}
+                    error={caseNumberTemplateError}
+                    minCharacters={3}
+                    maxCharacters={CASE_NUMBER_TEMPLATE_MAX_LENGTH}
+                    hint="Unterstützte Platzhalter: %YYY, %Y, %M, %D, %h, %m und genau einmal %I(n) mit 4 bis 12 Stellen, z. B. VG-%YYY-%I(6)."
+                />
+            }
+        </Stack>
+    );
+});

--- a/app/src/modules/process/dialogs/process-settings-dialog/process-settings-dialog.tsx
+++ b/app/src/modules/process/dialogs/process-settings-dialog/process-settings-dialog.tsx
@@ -1,8 +1,8 @@
 import {ProcessEntity} from '../../entities/process-entity';
 import {ProcessVersionEntity} from '../../entities/process-version-entity';
-import {Box, Dialog, DialogContent, Tab, Tabs} from '@mui/material';
+import {Box, Button, Dialog, DialogActions, DialogContent, Tab, Tabs} from '@mui/material';
 import {DialogTitleWithClose} from '../../../../components/dialog-title-with-close/dialog-title-with-close';
-import {useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import {VDepartmentShadowedApiService} from '../../../departments/services/v-department-shadowed-api-service';
 import {VDepartmentShadowedEntity} from '../../../departments/entities/v-department-shadowed-entity';
 import {useAppDispatch} from '../../../../hooks/use-app-dispatch';
@@ -11,12 +11,18 @@ import {ProcessSettingsDialogProcessAccessTab} from './process-settings-dialog-p
 import {TeamEntity} from '../../../teams/entities/team-entity';
 import {TeamsApiService} from '../../../teams/services/teams-api-service';
 import {ProcessSettingsDialogProcessInstanceAccessPresetTab} from './process-settings-dialog-process-instance-access-preset-tab';
+import {ProcessSettingsDialogGeneralTab, type ProcessSettingsDialogGeneralTabHandle} from './process-settings-dialog-general-tab';
+import Save from '@aivot/mui-material-symbols-400-outlined/dist/save/Save';
+import {useRetainedDialogValue} from '../../../../hooks/use-retained-dialog-value';
+import {ProcessSettingsDialogVersionTab, type ProcessSettingsDialogVersionTabHandle} from './process-settings-dialog-version-tab';
 
 interface ProcessSettingsDialogProps {
     open: boolean;
     onClose: () => void;
     process: ProcessEntity;
     version: ProcessVersionEntity;
+    onProcessChange: (process: ProcessEntity) => void;
+    onVersionChange: (version: ProcessVersionEntity) => void;
 }
 
 export function ProcessSettingsDialog(props: ProcessSettingsDialogProps) {
@@ -27,14 +33,35 @@ export function ProcessSettingsDialog(props: ProcessSettingsDialogProps) {
         onClose,
         process,
         version,
+        onProcessChange,
+        onVersionChange,
     } = props;
 
-    const [currentTab, setCurrentTab] = useState(1);
+    const [currentTab, setCurrentTab] = useState(0);
+    const [hasUnsavedGeneralChanges, setHasUnsavedGeneralChanges] = useState(false);
+    const [isSavingGeneralSettings, setIsSavingGeneralSettings] = useState(false);
+    const [hasGeneralValidationError, setHasGeneralValidationError] = useState(false);
+    const [hasUnsavedVersionChanges, setHasUnsavedVersionChanges] = useState(false);
+    const [isSavingVersionSettings, setIsSavingVersionSettings] = useState(false);
+    const [hasVersionValidationError, setHasVersionValidationError] = useState(false);
     const [hasUnsavedProcessAccessChanges, setHasUnsavedProcessAccessChanges] = useState(false);
     const [hasUnsavedProcessInstanceAccessPresetChanges, setHasUnsavedProcessInstanceAccessPresetChanges] = useState(false);
+    const generalTabRef = useRef<ProcessSettingsDialogGeneralTabHandle | null>(null);
+    const versionTabRef = useRef<ProcessSettingsDialogVersionTabHandle | null>(null);
+    const renderProcess = useRetainedDialogValue(open, process);
+    const renderVersion = useRetainedDialogValue(open, version);
+    const renderOnProcessChange = useRetainedDialogValue(open, onProcessChange);
+    const renderOnVersionChange = useRetainedDialogValue(open, onVersionChange);
+
     useEffect(() => {
         if (open) {
-            setCurrentTab(1);
+            setCurrentTab(0);
+            setHasUnsavedGeneralChanges(false);
+            setIsSavingGeneralSettings(false);
+            setHasGeneralValidationError(false);
+            setHasUnsavedVersionChanges(false);
+            setIsSavingVersionSettings(false);
+            setHasVersionValidationError(false);
             setHasUnsavedProcessAccessChanges(false);
             setHasUnsavedProcessInstanceAccessPresetChanges(false);
         }
@@ -68,7 +95,7 @@ export function ProcessSettingsDialog(props: ProcessSettingsDialogProps) {
         <Dialog
             open={open}
             onClose={onClose}
-            maxWidth="xl"
+            maxWidth="lg"
             fullWidth={true}
         >
             <DialogTitleWithClose onClose={onClose}>
@@ -77,6 +104,7 @@ export function ProcessSettingsDialog(props: ProcessSettingsDialogProps) {
 
             <DialogContent
                 sx={{
+                    mt: -1,
                     p: 0,
                 }}
             >
@@ -86,11 +114,19 @@ export function ProcessSettingsDialog(props: ProcessSettingsDialogProps) {
                     }}
                     value={currentTab}
                     onChange={(_, newValue) => {
-                        if (currentTab === 1 && newValue !== currentTab && hasUnsavedProcessAccessChanges) {
+                        if (currentTab === 0 && newValue !== currentTab && hasUnsavedGeneralChanges) {
+                            dispatch(showWarningSnackbar('Bitte speichern Sie zuerst die Änderungen in den allgemeinen Einstellungen.'));
+                            return;
+                        }
+                        if (currentTab === 1 && newValue !== currentTab && hasUnsavedVersionChanges) {
+                            dispatch(showWarningSnackbar('Bitte speichern Sie zuerst die Änderungen in den versionsspezifischen Einstellungen.'));
+                            return;
+                        }
+                        if (currentTab === 2 && newValue !== currentTab && hasUnsavedProcessAccessChanges) {
                             dispatch(showWarningSnackbar('Bitte speichern Sie zuerst die Änderungen in den Prozessberechtigungen.'));
                             return;
                         }
-                        if (currentTab === 2 && newValue !== currentTab && hasUnsavedProcessInstanceAccessPresetChanges) {
+                        if (currentTab === 3 && newValue !== currentTab && hasUnsavedProcessInstanceAccessPresetChanges) {
                             dispatch(showWarningSnackbar('Bitte speichern Sie zuerst die Änderungen in den Berechtigungen für neue Vorgänge.'));
                             return;
                         }
@@ -101,18 +137,21 @@ export function ProcessSettingsDialog(props: ProcessSettingsDialogProps) {
                     <Tab
                         value={0}
                         label="Allgemeine Einstellungen"
-                        disabled={true}
                     />
                     <Tab
                         value={1}
-                        label="Berechtigungen des Prozesses"
+                        label="Versionsspezifische Einstellungen"
                     />
                     <Tab
                         value={2}
-                        label="Berechtigungen für neue Vorgänge"
+                        label="Berechtigungen des Prozesses"
                     />
                     <Tab
                         value={3}
+                        label="Berechtigungen für neue Vorgänge"
+                    />
+                    <Tab
+                        value={4}
                         label="Testprofile"
                         disabled={true}
                     />
@@ -124,21 +163,46 @@ export function ProcessSettingsDialog(props: ProcessSettingsDialogProps) {
                     }}
                 >
                     {
-                        open && currentTab === 1 &&
+                        currentTab === 0 &&
+                        <ProcessSettingsDialogGeneralTab
+                            ref={generalTabRef}
+                            open={open}
+                            process={renderProcess}
+                            departments={departments}
+                            onProcessChange={renderOnProcessChange}
+                            onUnsavedChangesChange={setHasUnsavedGeneralChanges}
+                            onSavingChange={setIsSavingGeneralSettings}
+                            onValidationErrorChange={setHasGeneralValidationError}
+                        />
+                    }
+                    {
+                        currentTab === 1 &&
+                        <ProcessSettingsDialogVersionTab
+                            ref={versionTabRef}
+                            open={open}
+                            version={renderVersion}
+                            onVersionChange={renderOnVersionChange}
+                            onUnsavedChangesChange={setHasUnsavedVersionChanges}
+                            onSavingChange={setIsSavingVersionSettings}
+                            onValidationErrorChange={setHasVersionValidationError}
+                        />
+                    }
+                    {
+                        currentTab === 2 &&
                         <ProcessSettingsDialogProcessAccessTab
                             open={open}
-                            process={process}
+                            process={renderProcess}
                             departments={departments}
                             teams={teams}
                             onUnsavedChangesChange={setHasUnsavedProcessAccessChanges}
                         />
                     }
                     {
-                        open && currentTab === 2 &&
+                        currentTab === 3 &&
                         <ProcessSettingsDialogProcessInstanceAccessPresetTab
                             open={open}
-                            process={process}
-                            version={version}
+                            process={renderProcess}
+                            version={renderVersion}
                             departments={departments}
                             teams={teams}
                             onUnsavedChangesChange={setHasUnsavedProcessInstanceAccessPresetChanges}
@@ -146,6 +210,41 @@ export function ProcessSettingsDialog(props: ProcessSettingsDialogProps) {
                     }
                 </Box>
             </DialogContent>
+            <DialogActions sx={{px: 2}}>
+                {
+                    currentTab === 0 &&
+                    <Button
+                        variant="contained"
+                        startIcon={<Save/>}
+                        disabled={!hasUnsavedGeneralChanges || hasGeneralValidationError || isSavingGeneralSettings}
+                        onClick={() => {
+                            generalTabRef.current?.save();
+                        }}
+                    >
+                        Speichern
+                    </Button>
+                }
+                {
+                    currentTab === 1 &&
+                    <Button
+                        variant="contained"
+                        startIcon={<Save/>}
+                        disabled={!hasUnsavedVersionChanges || hasVersionValidationError || isSavingVersionSettings}
+                        onClick={() => {
+                            versionTabRef.current?.save();
+                        }}
+                    >
+                        Speichern
+                    </Button>
+                }
+                <Box sx={{flexGrow: 1}}/>
+                <Button
+                    onClick={onClose}
+                    disabled={isSavingGeneralSettings || isSavingVersionSettings}
+                >
+                    Schließen
+                </Button>
+            </DialogActions>
         </Dialog>
     );
 }

--- a/app/src/modules/process/entities/process-entity.ts
+++ b/app/src/modules/process/entities/process-entity.ts
@@ -3,6 +3,7 @@ export interface ProcessEntity {
     internalTitle: string;
     departmentId: number;
     accessKey: string;
+    slug: string;
     versionCount: number;
     draftedVersion: number | null;
     publishedVersion: number | null;

--- a/app/src/modules/process/entities/process-slug-history-entity.ts
+++ b/app/src/modules/process/entities/process-slug-history-entity.ts
@@ -1,0 +1,5 @@
+export interface ProcessSlugHistoryEntity {
+    slug: string;
+    processId: number;
+    created: string;
+}

--- a/app/src/modules/process/pages/details/process-details-page.tsx
+++ b/app/src/modules/process/pages/details/process-details-page.tsx
@@ -2473,6 +2473,18 @@ export function ProcessDetailsPage(): ReactNode {
                 }}
                 process={processFlow.definition}
                 version={processFlow.version}
+                onProcessChange={(process) => {
+                    setProcessFlow((current) => current == null ? current : {
+                        ...current,
+                        definition: process,
+                    });
+                }}
+                onVersionChange={(version) => {
+                    setProcessFlow((current) => current == null ? current : {
+                        ...current,
+                        version,
+                    });
+                }}
             />
 
             <ProcessVersionsDialog

--- a/app/src/modules/process/pages/details/process-task-view-page-index.tsx
+++ b/app/src/modules/process/pages/details/process-task-view-page-index.tsx
@@ -119,7 +119,7 @@ export function ProcessTaskViewPageIndex(): ReactNode {
         const fileNumbers = item.instance?.assignedFileNumbers?.filter((value) => value.trim().length > 0) ?? [];
         const entries: StatusTablePropsItem[] = [
             {
-                label: 'Vorgangskennung',
+                label: 'Vorgangsschlüssel',
                 icon: <Inbox />,
                 children: renderLinkedValue(item.instance?.caseNumber ?? 'Nicht hinterlegt', processPath),
             },

--- a/app/src/modules/process/pages/list/process-list-page.tsx
+++ b/app/src/modules/process/pages/list/process-list-page.tsx
@@ -24,12 +24,13 @@ import {NewProcessDialog} from '../../dialogs/new-process-dialog';
 import {ProcessDefinitionVersionApiService} from '../../services/process-definition-version-api-service';
 import Route from '@aivot/mui-material-symbols-400-outlined/dist/route/Route';
 import {GenericPageHeaderProps} from '../../../../components/generic-page-header/generic-page-header-props';
-import {useNotImplemented} from '../../../../hooks/use-not-implemented';
 import {ProcessStatusChipGroup} from '../../components/process-status/process-status-chip-group';
 import {useAppDispatch} from '../../../../hooks/use-app-dispatch';
 import {clearLoadingMessage, setLoadingMessage} from '../../../../slices/shell-slice';
 import {showApiErrorSnackbar} from '../../../../slices/snackbar-slice';
 import {ProcessVersionsDialog} from '../../dialogs/process-versions-dialog';
+import {MoveProcessToDepartmentDialog} from '../../dialogs/move-process-to-department-dialog';
+import {ProcessListRowMenu} from '../../components/process-list-row-menu';
 
 const availableFilter = [
     {
@@ -51,7 +52,7 @@ const availableFilter = [
 ];
 
 interface ProcessListEntry extends ProcessEntity {
-    developingDepartmentName?: string;
+    managingDepartmentName?: string;
     lastEditorName?: string;
 }
 
@@ -138,7 +139,7 @@ const columns: GridColDef<ProcessListEntry>[] = [
                         }}
                         color="textSecondary"
                     >
-                        Entwickelt von: {params.row.developingDepartmentName ?? 'Unbekannt'}
+                        Verwaltet von: {params.row.managingDepartmentName ?? 'Unbekannt'}
                     </Typography>
                 </Box>
             );
@@ -192,8 +193,11 @@ export function ProcessListPage() {
 
     const [showAddDialog, setShowAddDialog] = useState(false);
     const [showVersionsDialogForProcess, setShowVersionsDialogForProcess] = useState<ProcessEntity | null>(null);
-
-    const notImplemented = useNotImplemented();
+    const [processToMove, setProcessToMove] = useState<ProcessEntity>();
+    const [rowMenu, setRowMenu] = useState<{
+        target: HTMLElement;
+        process: ProcessListEntry;
+    }>();
 
     useEffect(() => {
         new ProcessDefinitionVersionApiService()
@@ -267,7 +271,7 @@ export function ProcessListPage() {
     const fetch = useCallback(async (options: GenericListPropsFetchOptions<ProcessListEntry>) => {
         const deps = (await new DepartmentApiService().listAll()).content;
 
-        const formsPage = await new ProcessDefinitionApiService()
+        const processesPage = await new ProcessDefinitionApiService()
             .list(options.page, options.size, options.sort as any, options.order, {
                 internalTitle: options.search,
                 isPublished: options.filter === 'published',
@@ -275,16 +279,16 @@ export function ProcessListPage() {
                 isRevoked: options.filter === 'revoked',
             });
 
-        const extendedFormsPage: Page<ProcessListEntry> = {
-            ...formsPage,
-            content: formsPage.content.map(form => ({
-                ...form,
-                developingDepartmentName: deps.find(dep => dep.id === form.departmentId)?.name,
+        const extendedProcessesPage: Page<ProcessListEntry> = {
+            ...processesPage,
+            content: processesPage.content.map(process => ({
+                ...process,
+                managingDepartmentName: deps.find(dep => dep.id === process.departmentId)?.name,
                 lastEditorName: '',
             })),
         };
 
-        return extendedFormsPage;
+        return extendedProcessesPage;
     }, []);
 
     const noDataPlaceholder = useMemo(() => (
@@ -357,8 +361,11 @@ export function ProcessListPage() {
         },
         {
             icon: <MoreVertOutlinedIcon/>,
-            onClick: () => {
-                notImplemented();
+            onClick: (event: React.MouseEvent<HTMLElement>) => {
+                setRowMenu({
+                    target: event.currentTarget as HTMLElement,
+                    process: item,
+                });
             },
             tooltip: 'Optionen',
         },
@@ -384,7 +391,7 @@ export function ProcessListPage() {
                     getRowIdentifier={getRowId}
                     noDataPlaceholder={noDataPlaceholder}
                     noSearchResultsPlaceholder="Keine Prozesse gefunden"
-                    rowActionsCount={4}
+                    rowActionsCount={5}
                     rowActions={rowActions}
                     defaultSortField="internalTitle"
                     disableFullWidthToggle={true}
@@ -413,6 +420,32 @@ export function ProcessListPage() {
                         if (listControlRef.current) {
                             listControlRef.current.refresh();
                         }
+                    }}
+                />
+            }
+
+            {
+                rowMenu != null &&
+                <ProcessListRowMenu
+                    anchorEl={rowMenu.target}
+                    process={rowMenu.process}
+                    onClose={() => {
+                        setRowMenu(undefined);
+                    }}
+                    onMoveProcessToDepartment={setProcessToMove}
+                />
+            }
+
+            {
+                processToMove != null &&
+                <MoveProcessToDepartmentDialog
+                    processId={processToMove.id}
+                    onClose={() => {
+                        setProcessToMove(undefined);
+                    }}
+                    onMoved={() => {
+                        setProcessToMove(undefined);
+                        listControlRef.current?.refresh();
                     }}
                 />
             }

--- a/app/src/modules/process/services/process-definition-api-service.ts
+++ b/app/src/modules/process/services/process-definition-api-service.ts
@@ -2,15 +2,21 @@ import {BaseCrudApiService} from "../../../services/base-crud-api-service";
 import {ProcessEntity} from "../entities/process-entity";
 import {ProcessExport} from "../entities/process-export";
 import {ProcessVersionEntity} from '../entities/process-version-entity';
+import {ProcessSlugHistoryEntity} from '../entities/process-slug-history-entity';
 
 interface ProcessDefinitionFilter {
     internalTitle: string;
     departmentId: number;
     departmentIdNot: number;
     accessKey: string;
+    slug: string;
     isPublished: boolean;
     isDrafted: boolean;
     isRevoked: boolean;
+}
+
+interface ProcessSlugAvailabilityResponse {
+    available: boolean;
 }
 
 export class ProcessDefinitionApiService extends BaseCrudApiService<
@@ -35,6 +41,7 @@ export class ProcessDefinitionApiService extends BaseCrudApiService<
             internalTitle: "",
             departmentId: 0,
             accessKey: "",
+            slug: "",
             versionCount: 0,
             draftedVersion: null,
             publishedVersion: null,
@@ -57,5 +64,24 @@ export class ProcessDefinitionApiService extends BaseCrudApiService<
 
     public addNewVersion(processId: number, sourceVersionNumber?: number): Promise<ProcessVersionEntity> {
         return this.post<any, ProcessVersionEntity>(`/api/processes/${processId}/new-version/${sourceVersionNumber ?? 'latest'}/`, {});
+    }
+
+    public listSlugHistory(processId: number): Promise<ProcessSlugHistoryEntity[]> {
+        return this.get<ProcessSlugHistoryEntity[]>(`/api/processes/${processId}/slug-history/`);
+    }
+
+    public clearSlugHistory(processId: number): Promise<void> {
+        return this.delete(`/api/processes/${processId}/slug-history/`);
+    }
+
+    public async checkSlugAvailability(slug: string, processId?: number): Promise<boolean> {
+        const response = await this.get<ProcessSlugAvailabilityResponse>('/api/processes/slug-availability/', {
+            query: {
+                slug,
+                processId,
+            },
+        });
+
+        return response.available;
     }
 }

--- a/app/src/modules/process/utils/process-case-number-utils.ts
+++ b/app/src/modules/process/utils/process-case-number-utils.ts
@@ -1,0 +1,103 @@
+export const CASE_NUMBER_TYPE_UUID = 'uuid';
+export const CASE_NUMBER_TYPE_TEMPLATE = 'template';
+
+export type CaseNumberType = typeof CASE_NUMBER_TYPE_UUID | typeof CASE_NUMBER_TYPE_TEMPLATE;
+
+export const CASE_NUMBER_TEMPLATE_MAX_LENGTH = 64;
+
+const CASE_NUMBER_MAX_RENDERED_LENGTH = 36;
+const CASE_NUMBER_PADDING_MIN = 4;
+const CASE_NUMBER_PADDING_MAX = 12;
+const CASE_NUMBER_INCREMENT_PATTERN = /^%I\((\d{1,2})\)/;
+
+const PLACEHOLDERS: Array<{
+    token: string;
+    renderedLength: number;
+}> = [
+    {
+        token: '%YYY',
+        renderedLength: 4,
+    },
+    {
+        token: '%Y',
+        renderedLength: 2,
+    },
+    {
+        token: '%M',
+        renderedLength: 2,
+    },
+    {
+        token: '%D',
+        renderedLength: 2,
+    },
+    {
+        token: '%h',
+        renderedLength: 2,
+    },
+    {
+        token: '%m',
+        renderedLength: 2,
+    },
+];
+
+export function getCaseNumberType(caseNumberTemplate: string | null | undefined): CaseNumberType {
+    return caseNumberTemplate == null ? CASE_NUMBER_TYPE_UUID : CASE_NUMBER_TYPE_TEMPLATE;
+}
+
+export function validateCaseNumberTemplate(caseNumberTemplate: string | null | undefined): string | undefined {
+    const template = caseNumberTemplate?.trim() ?? '';
+
+    if (template.length === 0) {
+        return 'Bitte geben Sie eine Vorgangsschlüssel-Formatvorlage an.';
+    }
+
+    if (template.length > CASE_NUMBER_TEMPLATE_MAX_LENGTH) {
+        return `Die Vorgangsschlüssel-Formatvorlage darf maximal ${CASE_NUMBER_TEMPLATE_MAX_LENGTH} Zeichen lang sein.`;
+    }
+
+    let renderedLength = 0;
+    let incrementCount = 0;
+
+    // Keep this parser aligned with the backend CaseNumberGeneratorService.
+    // The backend remains the final source of truth, this only gives immediate UI feedback.
+    for (let index = 0; index < template.length;) {
+        const incrementMatch = template.slice(index).match(CASE_NUMBER_INCREMENT_PATTERN);
+        if (incrementMatch != null) {
+            incrementCount += 1;
+
+            const padding = Number.parseInt(incrementMatch[1], 10);
+            if (padding < CASE_NUMBER_PADDING_MIN || padding > CASE_NUMBER_PADDING_MAX) {
+                return `Die Inkrement-Breite muss zwischen ${CASE_NUMBER_PADDING_MIN} und ${CASE_NUMBER_PADDING_MAX} Stellen liegen.`;
+            }
+
+            renderedLength += padding;
+            index += incrementMatch[0].length;
+            continue;
+        }
+
+        const placeholder = PLACEHOLDERS.find((item) => template.startsWith(item.token, index));
+        if (placeholder != null) {
+            renderedLength += placeholder.renderedLength;
+            index += placeholder.token.length;
+            continue;
+        }
+
+        if (template[index] === '%') {
+            return 'Die Vorgangsschlüssel-Formatvorlage enthält einen unbekannten Platzhalter.';
+        }
+
+        const codePoint = template.codePointAt(index);
+        renderedLength += 1;
+        index += codePoint == null ? 1 : String.fromCodePoint(codePoint).length;
+    }
+
+    if (incrementCount !== 1) {
+        return 'Die Vorgangsschlüssel-Formatvorlage muss genau einen Inkrement-Platzhalter im Format %I(n) enthalten.';
+    }
+
+    if (renderedLength > CASE_NUMBER_MAX_RENDERED_LENGTH) {
+        return `Der erzeugte Vorgangsschlüssel darf maximal ${CASE_NUMBER_MAX_RENDERED_LENGTH} Zeichen lang sein.`;
+    }
+
+    return undefined;
+}

--- a/app/src/modules/process/utils/process-slug-utils.ts
+++ b/app/src/modules/process/utils/process-slug-utils.ts
@@ -1,0 +1,33 @@
+import {slugify} from '../../../utils/slugify';
+
+export const PROCESS_SLUG_MAX_LENGTH = 128;
+
+export function normalizeProcessSlugInput(value: string | null | undefined): string | null {
+    const slug = slugify(value ?? '', PROCESS_SLUG_MAX_LENGTH)
+        .replace(/_/g, '-')
+        .replace(/--+/g, '-');
+
+    return slug.length > 0 ? slug : null;
+}
+
+export function validateProcessSlug(value: string | null | undefined): string | undefined {
+    const trimmedValue = value?.trim() ?? '';
+
+    if (trimmedValue.length === 0) {
+        return 'Bitte geben Sie einen URL-Namespace für den Prozess an.';
+    }
+
+    if (trimmedValue.length < 3) {
+        return 'Der URL-Namespace muss mindestens 3 Zeichen lang sein.';
+    }
+
+    if (trimmedValue.length > PROCESS_SLUG_MAX_LENGTH) {
+        return `Der URL-Namespace darf maximal ${PROCESS_SLUG_MAX_LENGTH} Zeichen lang sein.`;
+    }
+
+    if (!/^[a-z0-9-]+$/.test(trimmedValue)) {
+        return 'Der URL-Namespace darf nur aus Kleinbuchstaben, Zahlen und Bindestrichen bestehen.';
+    }
+
+    return undefined;
+}

--- a/app/src/pages/customer-pages/customer-form-page.tsx
+++ b/app/src/pages/customer-pages/customer-form-page.tsx
@@ -1,4 +1,4 @@
-import {useParams, useSearchParams} from 'react-router-dom';
+import {useNavigate, useParams, useSearchParams} from 'react-router-dom';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {Box, Button, Grid, Paper, ThemeProvider, Typography, useTheme} from '@mui/material';
 import {showDialog} from '../../slices/app-slice';
@@ -76,14 +76,16 @@ export function CustomerFormPage() {
     const baseTheme = useTheme();
 
     const [searchParams, setSearchParams] = useSearchParams();
+    const navigate = useNavigate();
+    const currentSearch = searchParams.toString();
     const testClaimKey = useMemo(() => searchParams.get(TestClaimSearchParam), [searchParams]);
     const metaDialogName = useMemo(() => searchParams.get(DialogSearchParam), [searchParams]);
 
     const {
-        processAccessKey,
+        processSlug,
         formSlug,
     } = useParams<{
-        processAccessKey: string;
+        processSlug: string;
         formSlug: string;
     }>();
 
@@ -107,17 +109,23 @@ export function CustomerFormPage() {
     const handledIdentityCallbackRef = useRef<string | null>(null);
 
     useEffect(() => {
-        if (processAccessKey == null || formSlug == null) {
+        if (processSlug == null || formSlug == null) {
             return;
         }
 
         new BaseApiService()
-            .get<RetrieveResponse>(`/api/public/forms/v1/${processAccessKey}/${formSlug}/`, {
+            .get<RetrieveResponse>(`/api/public/form/${processSlug}/${formSlug}/`, {
                 query: {
                     'test-claim': testClaimKey,
                 },
             })
             .then((res) => {
+                if (res.process.slug !== processSlug) {
+                    navigate(`/form/${res.process.slug}/${formSlug}${currentSearch.length > 0 ? `?${currentSearch}` : ''}`, {
+                        replace: true,
+                    });
+                }
+
                 setData(res);
                 setAllElements(flattenElements(res.layoutElement, false));
                 setDerivedData(createDerivedRuntimeElementData());
@@ -143,7 +151,7 @@ export function CustomerFormPage() {
                     }
                 }
             });
-    }, [processAccessKey, formSlug, testClaimKey]);
+    }, [processSlug, formSlug, testClaimKey, navigate, currentSearch]);
 
     const metaDialog = useAppSelector((state) => state.app.showDialog);
     const provider = useAppSelector(selectSystemConfigValue(SystemConfigKeys.provider.name));
@@ -168,9 +176,10 @@ export function CustomerFormPage() {
 
         new FormTriggerApiService()
             .getFormTheme(
-                process.accessKey,
+                process.slug,
                 node.configuration.formSlug,
-                version.processVersion,
+                undefined,
+                testClaimKey ?? undefined,
             )
             .then((res) => {
                 if (!isCancelled) {
@@ -187,7 +196,7 @@ export function CustomerFormPage() {
         return () => {
             isCancelled = true;
         };
-    }, [node, process, version]);
+    }, [node, process, testClaimKey, version]);
 
     const resolvedTheme = useMemo(() => {
         if (theme == null) {
@@ -229,7 +238,7 @@ export function CustomerFormPage() {
                 .postFormData<{
                     startedProcessAccessKey: string;
                 }>(
-                    `/api/public/forms/v1/${process?.accessKey}/${node.configuration.formSlug}/submit/`,
+                    `/api/public/form/${process?.slug}/${node.configuration.formSlug}/submit/`,
                     formData,
                     {
                         query: {
@@ -246,7 +255,7 @@ export function CustomerFormPage() {
 
     const handleDerive = (values: AuthoredElementValues, skipErrorsForElements: string[]) => {
         return new BaseApiService()
-            .post<AuthoredElementValues, ElementDerivationResponse>(`/api/public/forms/v1/${processAccessKey}/${formSlug}/derive/`, values, {
+            .post<AuthoredElementValues, ElementDerivationResponse>(`/api/public/form/${process?.slug ?? processSlug}/${formSlug}/derive/`, values, {
                 query: {
                     'test-claim': testClaimKey,
                     skipErrorsFor: skipErrorsForElements,
@@ -266,16 +275,14 @@ export function CustomerFormPage() {
         return null;
     }
 
-    const formAssetQueryParams = new URLSearchParams({
-        version: version.processVersion.toString(),
-    });
+    const formAssetQueryParams = new URLSearchParams();
     if (testClaimKey != null) {
         formAssetQueryParams.set('test-claim', testClaimKey);
     }
 
     const formAssetQuery = formAssetQueryParams.toString();
-    const formLogoUrl = `/api/public/forms/v1/${process.accessKey}/${node.configuration.formSlug}/logo/?${formAssetQuery}`;
-    const formFaviconUrl = `/api/public/forms/v1/${process.accessKey}/${node.configuration.formSlug}/favicon/?${formAssetQuery}`;
+    const formLogoUrl = `/api/public/form/${process.slug}/${node.configuration.formSlug}/logo/?${formAssetQuery}`;
+    const formFaviconUrl = `/api/public/form/${process.slug}/${node.configuration.formSlug}/favicon/?${formAssetQuery}`;
 
     return (
         <ThemeProvider theme={resolvedTheme}>

--- a/app/src/pages/customer-pages/customer-list-page.tsx
+++ b/app/src/pages/customer-pages/customer-list-page.tsx
@@ -37,7 +37,7 @@ function mapPublicFormListItem(form: FormTriggerListItem): FormCitizenListRespon
     }
 
     return {
-        slug: `forms/v1/${form.process.accessKey}/${formSlug}`,
+        slug: `form/${form.process.slug}/${formSlug}`,
         version: form.version.processVersion,
         title: resolveFormNodeName(formLayout, form.version),
         updated: form.version.updated,

--- a/app/src/pages/staff-pages/settings/components/application-settings/application-settings.tsx
+++ b/app/src/pages/staff-pages/settings/components/application-settings/application-settings.tsx
@@ -35,7 +35,6 @@ import {isStringNullOrEmpty} from '../../../../../utils/string-utils';
 import {SystemRolesApiService} from '../../../../../modules/system/services/system-roles-api-service';
 import {useConfirm} from '../../../../../providers/confirm-provider';
 import {DepartmentSelectField} from '../../../../../modules/departments/components/department-select-field';
-import {SelectDepartmentDialog} from '../../../../../modules/departments/dialogs/select-department-dialog';
 import {ModuleIcons} from '../../../../../shells/staff/data/module-icons';
 import Label from '@aivot/mui-material-symbols-400-outlined/dist/label/Label';
 import SupervisedUserCircle
@@ -46,14 +45,6 @@ import {
 import {ElementDerivationContext} from '../../../../../modules/elements/components/element-derivation-context';
 import {ElementType} from '../../../../../data/element-type/element-type';
 import {GroupLayout} from '../../../../../models/elements/form/layout/group-layout';
-
-type ListingPageDepartmentDialog = 'imprint' | 'privacy' | 'accessibility';
-
-const ListingPageDepartmentConfigKeys: Record<ListingPageDepartmentDialog, string> = {
-    imprint: SystemConfigKeys.provider.listingPage.imprintDepartmentId,
-    privacy: SystemConfigKeys.provider.listingPage.privacyDepartmentId,
-    accessibility: SystemConfigKeys.provider.listingPage.accessibilityDepartmentId,
-};
 
 export function ApplicationSettings() {
     const dispatch = useAppDispatch();
@@ -92,7 +83,6 @@ export function ApplicationSettings() {
     const [editedConfig, setEditedConfig] = useState<SystemConfigMap>({});
 
     const [departments, setDepartments] = useState<VDepartmentShadowedEntity[]>([]);
-    const [activeDepartmentDialog, setActiveDepartmentDialog] = useState<ListingPageDepartmentDialog | null>(null);
     const [themes, setThemes] = useState<SelectFieldComponentOption[]>([]);
     const [systemRoleOptions, setSystemRoleOptions] = useState<SelectFieldComponentOption[]>([]);
     const [isLoadingSystemRoles, setIsLoadingSystemRoles] = useState(true);
@@ -412,10 +402,6 @@ export function ApplicationSettings() {
     const currentGroup: GroupLayout | undefined = useMemo(() => {
         return groups[currentSettingsTab ?? availableTabs[0]];
     }, [groups, currentSettingsTab, availableTabs]);
-
-    const activeDepartmentDialogConfigKey = activeDepartmentDialog != null
-        ? ListingPageDepartmentConfigKeys[activeDepartmentDialog]
-        : undefined;
 
     if (localStorage.getItem('showNewSettings') != null) {
         return (
@@ -839,11 +825,8 @@ export function ApplicationSettings() {
                         <DepartmentSelectField
                             label="Text für das Impressum"
                             value={getConfiguredDepartment(SystemConfigKeys.provider.listingPage.imprintDepartmentId)}
-                            onOpenDialog={() => {
-                                setActiveDepartmentDialog('imprint');
-                            }}
-                            onClear={() => {
-                                handleChangeListingPageDepartment(SystemConfigKeys.provider.listingPage.imprintDepartmentId, null);
+                            onChange={(department) => {
+                                handleChangeListingPageDepartment(SystemConfigKeys.provider.listingPage.imprintDepartmentId, department?.id ?? null);
                             }}
                             disabled={!hasAccess}
                         />
@@ -858,11 +841,8 @@ export function ApplicationSettings() {
                         <DepartmentSelectField
                             label="Text für die Datenschutzerklärung"
                             value={getConfiguredDepartment(SystemConfigKeys.provider.listingPage.privacyDepartmentId)}
-                            onOpenDialog={() => {
-                                setActiveDepartmentDialog('privacy');
-                            }}
-                            onClear={() => {
-                                handleChangeListingPageDepartment(SystemConfigKeys.provider.listingPage.privacyDepartmentId, null);
+                            onChange={(department) => {
+                                handleChangeListingPageDepartment(SystemConfigKeys.provider.listingPage.privacyDepartmentId, department?.id ?? null);
                             }}
                             disabled={!hasAccess}
                         />
@@ -876,11 +856,8 @@ export function ApplicationSettings() {
                         <DepartmentSelectField
                             label="Text für die Erklärung der Barrierefreiheit"
                             value={getConfiguredDepartment(SystemConfigKeys.provider.listingPage.accessibilityDepartmentId)}
-                            onOpenDialog={() => {
-                                setActiveDepartmentDialog('accessibility');
-                            }}
-                            onClear={() => {
-                                handleChangeListingPageDepartment(SystemConfigKeys.provider.listingPage.accessibilityDepartmentId, null);
+                            onChange={(department) => {
+                                handleChangeListingPageDepartment(SystemConfigKeys.provider.listingPage.accessibilityDepartmentId, department?.id ?? null);
                             }}
                             disabled={!hasAccess}
                         />
@@ -997,24 +974,6 @@ export function ApplicationSettings() {
                 </Box>
             </form>
 
-            <SelectDepartmentDialog
-                open={activeDepartmentDialog != null}
-                onClose={() => {
-                    setActiveDepartmentDialog(null);
-                }}
-                onSelect={(department) => {
-                    if (activeDepartmentDialogConfigKey != null) {
-                        handleChangeListingPageDepartment(activeDepartmentDialogConfigKey, department.id);
-                    }
-
-                    setActiveDepartmentDialog(null);
-                }}
-                selectedDepartmentId={
-                    activeDepartmentDialogConfigKey != null
-                        ? getConfiguredDepartment(activeDepartmentDialogConfigKey)?.id
-                        : undefined
-                }
-            />
         </Box>
     );
 }

--- a/app/src/shells/customer/customer-shell-router.tsx
+++ b/app/src/shells/customer/customer-shell-router.tsx
@@ -23,7 +23,7 @@ const router = sentryCreateBrowserRouter(
                     element: <CustomerListPage/>,
                 },
                 {
-                    path: '/:processAccessKey/:formSlug',
+                    path: '/form/:processSlug/:formSlug',
                     element: <CustomerFormPage/>,
                 },
             ],

--- a/src/main/java/de/aivot/GoverBackend/plugins/core/v1/nodes/triggers/webhook/WebhookTriggerConfigV1.java
+++ b/src/main/java/de/aivot/GoverBackend/plugins/core/v1/nodes/triggers/webhook/WebhookTriggerConfigV1.java
@@ -57,8 +57,8 @@ public class WebhookTriggerConfigV1 {
 
     @Nullable
     @InputElementPOJOBinding(id = SLUG_CONFIG_KEY, type = ElementType.Text, properties = {
-            @ElementPOJOBindingProperty(key = "label", strValue = "Webhook-URL"),
-            @ElementPOJOBindingProperty(key = "hint", strValue = "Die URL, über die der Webhook angesprochen werden kann."),
+            @ElementPOJOBindingProperty(key = "label", strValue = "URL-Segment des Webhooks"),
+            @ElementPOJOBindingProperty(key = "hint", strValue = "Dieses Segment wird an den URL-Namespace des Prozesses angehängt. Der vollständige öffentliche API-Pfad lautet /api/public/webhook/{prozess-namespace}/{webhook-segment}/."),
             @ElementPOJOBindingProperty(key = "required", boolValue = true),
             @ElementPOJOBindingProperty(key = "destinationKey", strValue = WebhookTriggerConfigV1.SLUG_CONFIG_KEY),
     })

--- a/src/main/java/de/aivot/GoverBackend/plugins/core/v1/nodes/triggers/webhook/WebhookTriggerControllerV1.java
+++ b/src/main/java/de/aivot/GoverBackend/plugins/core/v1/nodes/triggers/webhook/WebhookTriggerControllerV1.java
@@ -5,7 +5,6 @@ import de.aivot.GoverBackend.lib.exceptions.ResponseException;
 import de.aivot.GoverBackend.process.entities.*;
 import de.aivot.GoverBackend.process.enums.ProcessInstanceStatus;
 import de.aivot.GoverBackend.process.enums.ProcessVersionStatus;
-import de.aivot.GoverBackend.process.filters.ProcessFilter;
 import de.aivot.GoverBackend.process.repositories.ProcessNodeRepository;
 import de.aivot.GoverBackend.process.repositories.ProcessTestClaimRepository;
 import de.aivot.GoverBackend.process.services.*;
@@ -58,22 +57,22 @@ public class WebhookTriggerControllerV1 {
     }
 
 
-    @RequestMapping(value = "/api/public/webhooks/v1/{accessKey}/{slug}/", method = {
+    @RequestMapping(value = "/api/public/webhook/{processSlug}/{slug}/", method = {
             RequestMethod.GET,
             RequestMethod.DELETE,
     }, produces = MediaType.APPLICATION_JSON_VALUE)
     public Response handleWithoutBody(
             @Nonnull HttpServletRequest request,
-            @Nonnull @PathVariable UUID accessKey,
+            @Nonnull @PathVariable String processSlug,
             @Nonnull @PathVariable String slug,
             @Nullable @RequestParam(value = TEST_CLAIM_QUERY_PARAM, required = false) String testClaimAccessKey,
             @Nullable @RequestParam(value = AUTH_TOKEN_QUERY_PARAM, required = false) String authToken,
             @Nullable @RequestHeader(name = AUTH_HEADER_NAME, required = false) String authorizationHeader
     ) throws ResponseException {
-        return handleRequest(request, accessKey, slug, null, new HashMap<>(), Map.of(), testClaimAccessKey, authToken, authorizationHeader);
+        return handleRequest(request, processSlug, slug, null, new HashMap<>(), Map.of(), testClaimAccessKey, authToken, authorizationHeader);
     }
 
-    @RequestMapping(value = "/api/public/webhooks/v1/{accessKey}/{slug}/xml/", method = {
+    @RequestMapping(value = "/api/public/webhook/{processSlug}/{slug}/xml/", method = {
             RequestMethod.POST,
             RequestMethod.PUT,
             RequestMethod.PATCH,
@@ -82,17 +81,17 @@ public class WebhookTriggerControllerV1 {
     }, produces = MediaType.APPLICATION_JSON_VALUE)
     public Response handleXml(
             @Nonnull HttpServletRequest request,
-            @Nonnull @PathVariable UUID accessKey,
+            @Nonnull @PathVariable String processSlug,
             @Nonnull @PathVariable String slug,
             @Nonnull @RequestBody Map<String, Object> payload,
             @Nullable @RequestParam(value = TEST_CLAIM_QUERY_PARAM, required = false) String testClaimAccessKey,
             @Nullable @RequestParam(value = AUTH_TOKEN_QUERY_PARAM, required = false) String authToken,
             @Nullable @RequestHeader(name = AUTH_HEADER_NAME, required = false) String authorizationHeader
     ) throws ResponseException {
-        return handleRequest(request, accessKey, slug, WebhookTriggerConfigV1.REQUEST_BODY_TYPE_OPTION_XML, payload, Map.of(), testClaimAccessKey, authToken, authorizationHeader);
+        return handleRequest(request, processSlug, slug, WebhookTriggerConfigV1.REQUEST_BODY_TYPE_OPTION_XML, payload, Map.of(), testClaimAccessKey, authToken, authorizationHeader);
     }
 
-    @RequestMapping(value = "/api/public/webhooks/v1/{accessKey}/{slug}/json/", method = {
+    @RequestMapping(value = "/api/public/webhook/{processSlug}/{slug}/json/", method = {
             RequestMethod.POST,
             RequestMethod.PUT,
             RequestMethod.PATCH,
@@ -101,17 +100,17 @@ public class WebhookTriggerControllerV1 {
     }, produces = MediaType.APPLICATION_JSON_VALUE)
     public Response handleJson(
             @Nonnull HttpServletRequest request,
-            @Nonnull @PathVariable UUID accessKey,
+            @Nonnull @PathVariable String processSlug,
             @Nonnull @PathVariable String slug,
             @Nonnull @RequestBody Map<String, Object> payload,
             @Nullable @RequestParam(value = TEST_CLAIM_QUERY_PARAM, required = false) String testClaimAccessKey,
             @Nullable @RequestParam(value = AUTH_TOKEN_QUERY_PARAM, required = false) String authToken,
             @Nullable @RequestHeader(name = AUTH_HEADER_NAME, required = false) String authorizationHeader
     ) throws ResponseException {
-        return handleRequest(request, accessKey, slug, WebhookTriggerConfigV1.REQUEST_BODY_TYPE_OPTION_JSON, payload, Map.of(), testClaimAccessKey, authToken, authorizationHeader);
+        return handleRequest(request, processSlug, slug, WebhookTriggerConfigV1.REQUEST_BODY_TYPE_OPTION_JSON, payload, Map.of(), testClaimAccessKey, authToken, authorizationHeader);
     }
 
-    @RequestMapping(value = "/api/public/webhooks/v1/{accessKey}/{slug}/form-data/", method = {
+    @RequestMapping(value = "/api/public/webhook/{processSlug}/{slug}/form-data/", method = {
             RequestMethod.POST,
             RequestMethod.PUT,
             RequestMethod.PATCH,
@@ -120,7 +119,7 @@ public class WebhookTriggerControllerV1 {
     }, produces = MediaType.APPLICATION_JSON_VALUE)
     public Response handleFormData(
             @Nonnull StandardMultipartHttpServletRequest request,
-            @Nonnull @PathVariable UUID accessKey,
+            @Nonnull @PathVariable String processSlug,
             @Nonnull @PathVariable String slug,
             @Nullable @RequestParam(value = TEST_CLAIM_QUERY_PARAM, required = false) String testClaimAccessKey,
             @Nullable @RequestParam(value = AUTH_TOKEN_QUERY_PARAM, required = false) String authToken,
@@ -136,12 +135,12 @@ public class WebhookTriggerControllerV1 {
                 payload.put(key, null);
             }
         }
-        return handleRequest(request, accessKey, slug, WebhookTriggerConfigV1.REQUEST_BODY_TYPE_OPTION_FORM, payload, request.getFileMap(), testClaimAccessKey, authToken, authorizationHeader);
+        return handleRequest(request, processSlug, slug, WebhookTriggerConfigV1.REQUEST_BODY_TYPE_OPTION_FORM, payload, request.getFileMap(), testClaimAccessKey, authToken, authorizationHeader);
     }
 
     @Nonnull
     private Response handleRequest(@Nonnull HttpServletRequest request,
-                                   @Nonnull UUID accessKey,
+                                   @Nonnull String processSlug,
                                    @Nonnull String slug,
                                    @Nullable String requestBody,
                                    @Nonnull Map<String, Object> payload,
@@ -149,7 +148,7 @@ public class WebhookTriggerControllerV1 {
                                    @Nullable String testClaimAccessKey,
                                    @Nullable String authToken,
                                    @Nullable String authorizationHeader) throws ResponseException {
-        var process = getProcess(accessKey);
+        var process = getProcess(processSlug);
         var testClaim = getTestClaim(process, testClaimAccessKey);
         var nodeEntities = retrieveWebhookNode(process, slug, request.getMethod(), requestBody, testClaim);
 
@@ -164,10 +163,16 @@ public class WebhookTriggerControllerV1 {
 
     @Nullable
     private ProcessTestClaimEntity getTestClaim(@Nonnull ProcessEntity process,
-                                                @Nullable String testClaimAccessKey) {
-        return testClaimAccessKey != null ? processTestClaimRepository
-                                            .findByProcessIdAndAccessKey(process.getId(), testClaimAccessKey)
-                                            .orElse(null) : null;
+                                                @Nullable String testClaimAccessKey) throws ResponseException {
+        if (testClaimAccessKey == null) {
+            return null;
+        }
+
+        // A provided test claim is part of the public routing contract. If it is wrong,
+        // the request must fail instead of silently falling back to the published version.
+        return processTestClaimRepository
+                .findByProcessIdAndAccessKey(process.getId(), testClaimAccessKey)
+                .orElseThrow(ResponseException::notFound);
     }
 
     @Nonnull
@@ -482,9 +487,9 @@ public class WebhookTriggerControllerV1 {
 
     }
 
-    private ProcessEntity getProcess(UUID accessKey) throws ResponseException {
+    private ProcessEntity getProcess(String processSlug) throws ResponseException {
         return processService
-                .retrieve(ProcessFilter.create().setAccessKey(accessKey))
-                .orElseThrow(() -> ResponseException.notFound("Kein Prozess mit dem angegebenen Access Key gefunden."));
+                .retrieveBySlugOrHistory(processSlug)
+                .orElseThrow(() -> ResponseException.notFound("Kein Prozess mit dem angegebenen Slug gefunden."));
     }
 }

--- a/src/main/java/de/aivot/GoverBackend/plugins/core/v1/nodes/triggers/webhook/WebhookTriggerNodeV1.java
+++ b/src/main/java/de/aivot/GoverBackend/plugins/core/v1/nodes/triggers/webhook/WebhookTriggerNodeV1.java
@@ -14,17 +14,19 @@ import de.aivot.GoverBackend.elements.models.elements.layout.ConfigLayoutElement
 import de.aivot.GoverBackend.elements.models.elements.layout.GroupLayoutElement;
 import de.aivot.GoverBackend.elements.utils.ElementPOJOMapper;
 import de.aivot.GoverBackend.lib.exceptions.ResponseException;
-import de.aivot.GoverBackend.models.config.GoverConfig;
 import de.aivot.GoverBackend.nocode.models.NoCodeExpression;
 import de.aivot.GoverBackend.nocode.models.NoCodeReference;
 import de.aivot.GoverBackend.nocode.models.NoCodeStaticValue;
 import de.aivot.GoverBackend.plugins.core.CorePlugin;
 import de.aivot.GoverBackend.plugins.core.v1.operators.bool.NoCodeOrOperator;
 import de.aivot.GoverBackend.plugins.core.v1.operators.common.NoCodeEqualsOperator;
+import de.aivot.GoverBackend.process.entities.ProcessEntity;
+import de.aivot.GoverBackend.process.entities.ProcessNodeEntity;
 import de.aivot.GoverBackend.process.enums.ProcessNodeType;
 import de.aivot.GoverBackend.process.exceptions.ProcessNodeExecutionException;
 import de.aivot.GoverBackend.process.exceptions.ProcessNodeExecutionExceptionInvalidConfiguration;
 import de.aivot.GoverBackend.process.exceptions.ProcessNodeExecutionExceptionUnknown;
+import de.aivot.GoverBackend.process.filters.ProcessNodeFilter;
 import de.aivot.GoverBackend.process.models.*;
 import de.aivot.GoverBackend.process.models.executionResult.ProcessNodeExecutionResult;
 import de.aivot.GoverBackend.process.models.executionResult.ProcessNodeExecutionResultTaskCompleted;
@@ -32,6 +34,7 @@ import de.aivot.GoverBackend.process.models.processContext.ProcessNodeDefinition
 import de.aivot.GoverBackend.process.models.processContext.ProcessNodeDefinitionTestingLayoutContext;
 import de.aivot.GoverBackend.process.models.processContext.ProcessNodeExecutionInitContext;
 import de.aivot.GoverBackend.process.repositories.ProcessNodeRepository;
+import de.aivot.GoverBackend.process.services.PublicUrlService;
 import de.aivot.GoverBackend.utils.FormattedStringBuilder;
 import de.aivot.GoverBackend.utils.StringUtils;
 import jakarta.annotation.Nonnull;
@@ -40,6 +43,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.LinkedList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -53,13 +57,13 @@ public class WebhookTriggerNodeV1 implements ProcessNodeDefinition<WebhookTrigge
     public static final String INITIAL_DATA_KEY_REQUEST = "request";
     public static final String INITIAL_DATA_KEY_STARTED = "started";
 
-    private final GoverConfig goverConfig;
+    private final PublicUrlService publicUrlService;
     private final ProcessNodeRepository processDefinitionNodeRepository;
 
     @Autowired
-    public WebhookTriggerNodeV1(GoverConfig goverConfig,
+    public WebhookTriggerNodeV1(PublicUrlService publicUrlService,
                                 ProcessNodeRepository processDefinitionNodeRepository) {
-        this.goverConfig = goverConfig;
+        this.publicUrlService = publicUrlService;
         this.processDefinitionNodeRepository = processDefinitionNodeRepository;
     }
 
@@ -155,11 +159,11 @@ public class WebhookTriggerNodeV1 implements ProcessNodeDefinition<WebhookTrigge
                 .findChild(WebhookTriggerConfigV1.SLUG_CONFIG_KEY, TextInputElement.class)
                 .ifPresent(field -> {
                     var pattern = new TextInputElementPattern()
-                            .setRegex("^[a-zA-Z0-9-]+$")
-                            .setMessage("Der Webhook-Slug darf nur aus Buchstaben, Zahlen und Bindestrichen bestehen.");
+                            .setRegex("^[a-z0-9-]+$")
+                            .setMessage("Das URL-Segment des Webhooks darf nur aus Kleinbuchstaben, Zahlen und Bindestrichen bestehen.");
                     field.setPattern(pattern);
 
-                    field.setPrefix(goverConfig.createUrlWithTrailingSlash("…/webhooks/…"));
+                    field.setPrefix(publicUrlService.createProcessNamespaceDisplayPrefix());
                 });
 
         // Add request method select options
@@ -330,6 +334,40 @@ public class WebhookTriggerNodeV1 implements ProcessNodeDefinition<WebhookTrigge
 
     @Nullable
     @Override
+    public Map<String, String> validateConfiguration(@Nonnull ProcessNodeEntity processNodeEntity,
+                                                     @Nonnull WebhookTriggerConfigV1 configuration) throws ResponseException {
+        var errors = new LinkedHashMap<String, String>();
+        var webhookSlug = configuration.slug;
+
+        if (StringUtils.isNotNullOrEmpty(webhookSlug)) {
+            if (!webhookSlug.matches("^[a-z0-9-]+$")) {
+                errors.put(
+                        WebhookTriggerConfigV1.SLUG_CONFIG_KEY,
+                        "Das URL-Segment des Webhooks darf nur aus Kleinbuchstaben, Zahlen und Bindestrichen bestehen."
+                );
+            }
+
+            var duplicateNodeFilter = ProcessNodeFilter
+                    .create()
+                    .setNotId(processNodeEntity.getId())
+                    .setProcessId(processNodeEntity.getProcessId())
+                    .setProcessVersion(processNodeEntity.getProcessVersion())
+                    .setProcessNodeDefinitionKey(processNodeEntity.getProcessNodeDefinitionKey())
+                    .addConfigEquals(WebhookTriggerConfigV1.SLUG_CONFIG_KEY, webhookSlug);
+
+            if (processDefinitionNodeRepository.exists(duplicateNodeFilter.build())) {
+                errors.putIfAbsent(
+                        WebhookTriggerConfigV1.SLUG_CONFIG_KEY,
+                        "Das URL-Segment des Webhooks wird in dieser Prozessversion bereits von einem anderen Webhook verwendet."
+                );
+            }
+        }
+
+        return errors.isEmpty() ? null : errors;
+    }
+
+    @Nullable
+    @Override
     public GroupLayoutElement getTestingLayout(@Nonnull ProcessNodeDefinitionTestingLayoutContext<WebhookTriggerConfigV1> context) throws ResponseException {
         WebhookTriggerConfigV1 config = context.configuration();
 
@@ -341,7 +379,7 @@ public class WebhookTriggerNodeV1 implements ProcessNodeDefinition<WebhookTrigge
 
         var triggerUrl = appendQueryParameter(
                 createWebhookUrl(
-                        context.processDefinition().getAccessKey().toString(),
+                        context.processDefinition(),
                         config.slug,
                         config.requestMethod,
                         config.requestBodyConfig != null ? config.requestBodyConfig.requestBodyType : null
@@ -532,13 +570,12 @@ public class WebhookTriggerNodeV1 implements ProcessNodeDefinition<WebhookTrigge
     }
 
     @Nonnull
-    private String createWebhookUrl(@Nonnull String processAccessKey,
+    private String createWebhookUrl(@Nonnull ProcessEntity process,
                                     @Nullable String slug,
                                     @Nullable String requestMethod,
                                     @Nullable String requestBodyType) {
-        return goverConfig.createUrlWithTrailingSlash(
-                "/api/public/webhooks/v1",
-                processAccessKey,
+        return publicUrlService.createWebhookUrl(
+                process,
                 slug,
                 resolveRequestBodyPathSegment(requestMethod, requestBodyType)
         );

--- a/src/main/java/de/aivot/GoverBackend/plugins/form/v1/nodes/FormTriggerConfigV1.java
+++ b/src/main/java/de/aivot/GoverBackend/plugins/form/v1/nodes/FormTriggerConfigV1.java
@@ -13,8 +13,8 @@ import java.util.List;
 public class FormTriggerConfigV1 {
     public static final String FORM_SLUG = "formSlug";
     @InputElementPOJOBinding(id = FORM_SLUG, type = ElementType.Text, properties = {
-            @ElementPOJOBindingProperty(key = "label", strValue = "Formular-URL"),
-            @ElementPOJOBindingProperty(key = "hint", strValue = "Die URL, über die das Formular angesprochen werden kann."),
+            @ElementPOJOBindingProperty(key = "label", strValue = "URL-Segment des Formulars"),
+            @ElementPOJOBindingProperty(key = "hint", strValue = "Dieses Segment wird an den URL-Namespace des Prozesses angehängt. Der vollständige öffentliche Pfad lautet /form/{prozess-namespace}/{formular-segment}/."),
             @ElementPOJOBindingProperty(key = "required", boolValue = true)
     })
     public String formSlug;

--- a/src/main/java/de/aivot/GoverBackend/plugins/form/v1/nodes/FormTriggerControllerV1.java
+++ b/src/main/java/de/aivot/GoverBackend/plugins/form/v1/nodes/FormTriggerControllerV1.java
@@ -42,7 +42,6 @@ import de.aivot.GoverBackend.process.entities.*;
 import de.aivot.GoverBackend.process.enums.ProcessInstanceStatus;
 import de.aivot.GoverBackend.process.enums.ProcessVersionStatus;
 import de.aivot.GoverBackend.process.filters.ProcessNodeFilter;
-import de.aivot.GoverBackend.process.filters.ProcessTestClaimFilter;
 import de.aivot.GoverBackend.process.filters.ProcessVersionFilter;
 import de.aivot.GoverBackend.process.services.*;
 import de.aivot.GoverBackend.storage.entities.StorageProviderEntity;
@@ -72,7 +71,7 @@ import java.time.Instant;
 import java.util.*;
 
 @RestController
-@RequestMapping("/api/public/forms/v1/{processAccessKey}/{formSlug}/")
+@RequestMapping("/api/public/form/{processSlug}/{formSlug}/")
 public class FormTriggerControllerV1 {
     public static final String TEST_CLAIM_QUERY_PARAM = "test-claim";
     public static final String VERSION_QUERY_PARAM = "version";
@@ -167,14 +166,14 @@ public class FormTriggerControllerV1 {
 
     @GetMapping("")
     public RetrieveResponse retrieve(@Nullable @AuthenticationPrincipal Jwt jwt,
-                                     @Nonnull @PathVariable UUID processAccessKey,
+                                     @Nonnull @PathVariable String processSlug,
                                      @Nonnull @PathVariable String formSlug,
                                      @Nullable @RequestParam(value = TEST_CLAIM_QUERY_PARAM, required = false) String testClaimAccessKey,
                                      @Nullable @CookieValue(value = IdentityController.IDENTITY_COOKIE_NAME, required = false) String identitySessionId) throws ResponseException {
         var execUser = getExecUser(jwt);
 
-        var process = getProcessEntity(processAccessKey);
-        var processVersion = getProcessVersionEntity(testClaimAccessKey, null, process);
+        var process = getProcessEntity(processSlug);
+        var processVersion = getProcessVersionEntity(testClaimAccessKey, null, process, execUser);
         var node = getProcessNodeEntity(formSlug, process, processVersion);
         var provider = getProvider(node);
         var config = getConfigurationDetails(node, provider, execUser);
@@ -347,7 +346,7 @@ public class FormTriggerControllerV1 {
                     "Otherwise, a default value will be provided."
     )
     public MaxFileSizeDto getMaxFileSize(@Nullable @AuthenticationPrincipal Jwt jwt,
-                                         @Nonnull @PathVariable UUID processAccessKey,
+                                         @Nonnull @PathVariable String processSlug,
                                          @Nonnull @PathVariable String formSlug,
                                          @Nullable @RequestParam(value = TEST_CLAIM_QUERY_PARAM, required = false) String testClaimAccessKey,
                                          @Nullable @CookieValue(value = IdentityController.IDENTITY_COOKIE_NAME, required = false) String identitySessionId) throws ResponseException {
@@ -374,7 +373,7 @@ public class FormTriggerControllerV1 {
                     "If no payment provider is linked, the response will indicate that there are no costs."
     )
     public FormCostCalculationResponseDTO calculateCosts(@Nullable @AuthenticationPrincipal Jwt jwt,
-                                                         @Nonnull @PathVariable UUID processAccessKey,
+                                                         @Nonnull @PathVariable String processSlug,
                                                          @Nonnull @PathVariable String formSlug,
                                                          @Nullable @RequestParam(value = TEST_CLAIM_QUERY_PARAM, required = false) String testClaimAccessKey,
                                                          @Nullable @CookieValue(value = IdentityController.IDENTITY_COOKIE_NAME, required = false) UUID identitySessionId,
@@ -391,7 +390,7 @@ public class FormTriggerControllerV1 {
                     "Options are available to skip certain derivation aspects for specific elements."
     )
     public ElementDerivationResponse derive(@Nullable @AuthenticationPrincipal Jwt jwt,
-                                            @Nonnull @PathVariable UUID processAccessKey,
+                                            @Nonnull @PathVariable String processSlug,
                                             @Nonnull @PathVariable String formSlug,
                                             @Nullable @RequestParam(value = TEST_CLAIM_QUERY_PARAM, required = false) String testClaimAccessKey,
                                             @Nullable @CookieValue(value = IdentityController.IDENTITY_COOKIE_NAME, required = false) String identitySessionId,
@@ -401,8 +400,8 @@ public class FormTriggerControllerV1 {
                                             @Nullable @RequestParam(value = "skipValuesFor") List<String> skipValuesFor,
                                             @Nullable @RequestParam(value = "skipOverridesFor") List<String> skipOverridesFor) throws ResponseException {
         var execUser = getExecUser(jwt);
-        var process = getProcessEntity(processAccessKey);
-        var processVersion = getProcessVersionEntity(testClaimAccessKey, null, process);
+        var process = getProcessEntity(processSlug);
+        var processVersion = getProcessVersionEntity(testClaimAccessKey, null, process, execUser);
         var node = getProcessNodeEntity(formSlug, process, processVersion);
         var provider = getProvider(node);
         var config = getConfigurationDetails(node, provider, execUser);
@@ -432,7 +431,7 @@ public class FormTriggerControllerV1 {
 
     @PostMapping("submit/")
     public SubmissionStatusResponseDTO submit(@Nullable @AuthenticationPrincipal Jwt jwt,
-                                              @Nonnull @PathVariable UUID processAccessKey,
+                                              @Nonnull @PathVariable String processSlug,
                                               @Nonnull @PathVariable String formSlug,
                                               @Nullable @RequestParam(value = TEST_CLAIM_QUERY_PARAM, required = false) String testClaimAccessKey,
                                               @Nullable @CookieValue(value = IdentityController.IDENTITY_COOKIE_NAME, required = false) String identitySessionId,
@@ -441,8 +440,8 @@ public class FormTriggerControllerV1 {
                                               @Nullable @RequestParam(value = "fileUris", required = false) List<String> fileUris,
                                               @Nonnull HttpServletResponse response) throws ResponseException {
         var execUser = getExecUser(jwt);
-        var process = getProcessEntity(processAccessKey);
-        var processVersion = getProcessVersionEntity(testClaimAccessKey, null, process);
+        var process = getProcessEntity(processSlug);
+        var processVersion = getProcessVersionEntity(testClaimAccessKey, null, process, execUser);
         var node = getProcessNodeEntity(formSlug, process, processVersion);
         var provider = getProvider(node);
         var config = getConfigurationDetails(node, provider, execUser);
@@ -475,13 +474,14 @@ public class FormTriggerControllerV1 {
 
         var effectiveValues = derivedRuntimeElementData.getEffectiveValues();
 
-        var testClaim = processTestClaimService
-                .retrieve(ProcessTestClaimFilter
-                        .create()
-                        .setProcessId(processVersion.getProcessId())
-                        .setProcessVersion(processVersion.getProcessVersion())
-                )
-                .orElse(null);
+        // Only bind a started instance to a test claim when the caller explicitly
+        // proves the claim through the public URL. Looking up by process/version alone
+        // would accidentally mark normal public submissions as test submissions.
+        var testClaim = testClaimAccessKey != null
+                ? processTestClaimService
+                .retrieveByAccessKey(process.getId(), testClaimAccessKey)
+                .orElseThrow(ResponseException::notFound)
+                : null;
 
 
         testCaptchaReplayProtection(config.configuration().formLayout, effectiveValues);
@@ -640,12 +640,12 @@ public class FormTriggerControllerV1 {
                     "Includes information such as colors, fonts, logos, and other visual elements that define the form's appearance."
     )
     public ThemeResponseDTO getTheme(@Nullable @AuthenticationPrincipal Jwt jwt,
-                                     @Nonnull @PathVariable UUID processAccessKey,
+                                     @Nonnull @PathVariable String processSlug,
                                      @Nonnull @PathVariable String formSlug,
                                      @Nullable @RequestParam(value = TEST_CLAIM_QUERY_PARAM, required = false) String testClaimAccessKey,
                                      @Nullable @RequestParam(value = VERSION_QUERY_PARAM, required = false) Integer processVersion
     ) throws ResponseException {
-        var context = resolveFormTriggerContext(jwt, processAccessKey, formSlug, testClaimAccessKey, processVersion);
+        var context = resolveFormTriggerContext(jwt, processSlug, formSlug, testClaimAccessKey, processVersion);
         var theme = getFormTheme(context.formLayout());
         return ThemeResponseDTO.fromEntity(theme);
     }
@@ -657,13 +657,13 @@ public class FormTriggerControllerV1 {
                     "If the form does not have a custom logo, a default logo URL will be provided."
     )
     public void getLogo(@Nullable @AuthenticationPrincipal Jwt jwt,
-                        @Nonnull @PathVariable UUID processAccessKey,
+                        @Nonnull @PathVariable String processSlug,
                         @Nonnull @PathVariable String formSlug,
                         @Nullable @RequestParam(value = TEST_CLAIM_QUERY_PARAM, required = false) String testClaimAccessKey,
                         @Nullable @RequestParam(value = VERSION_QUERY_PARAM, required = false) Integer processVersion,
                         @Nonnull HttpServletResponse response
     ) throws ResponseException, IOException {
-        var context = resolveFormTriggerContext(jwt, processAccessKey, formSlug, testClaimAccessKey, processVersion);
+        var context = resolveFormTriggerContext(jwt, processSlug, formSlug, testClaimAccessKey, processVersion);
         var logoKey = getFormLogoKey(context.formLayout());
 
         String redirectUrl;
@@ -683,13 +683,13 @@ public class FormTriggerControllerV1 {
                     "If the form does not have a custom favicon, a default favicon URL will be provided."
     )
     public void getFavicon(@Nullable @AuthenticationPrincipal Jwt jwt,
-                           @Nonnull @PathVariable UUID processAccessKey,
+                           @Nonnull @PathVariable String processSlug,
                            @Nonnull @PathVariable String formSlug,
                            @Nullable @RequestParam(value = TEST_CLAIM_QUERY_PARAM, required = false) String testClaimAccessKey,
                            @Nullable @RequestParam(value = VERSION_QUERY_PARAM, required = false) Integer processVersion,
                            @Nonnull HttpServletResponse response
     ) throws ResponseException, IOException {
-        var context = resolveFormTriggerContext(jwt, processAccessKey, formSlug, testClaimAccessKey, processVersion);
+        var context = resolveFormTriggerContext(jwt, processSlug, formSlug, testClaimAccessKey, processVersion);
         var faviconKey = getFormFaviconKey(context.formLayout());
 
         String redirectUrl;
@@ -709,7 +709,7 @@ public class FormTriggerControllerV1 {
                     "If the form does not have a custom favicon, a default favicon URL will be provided."
     )
     public void getPrint(@Nullable @AuthenticationPrincipal Jwt jwt,
-                         @Nonnull @PathVariable UUID processAccessKey,
+                         @Nonnull @PathVariable String processSlug,
                          @Nonnull @PathVariable String formSlug,
                          @Nonnull @PathVariable UUID instanceAccessKey,
                          @Nullable @RequestParam(value = "version", required = false) Integer version,
@@ -725,7 +725,7 @@ public class FormTriggerControllerV1 {
                     "If the form does not have a custom favicon, a default favicon URL will be provided."
     )
     public void getStatus(@Nullable @AuthenticationPrincipal Jwt jwt,
-                          @Nonnull @PathVariable UUID processAccessKey,
+                          @Nonnull @PathVariable String processSlug,
                           @Nonnull @PathVariable String formSlug,
                           @Nonnull @PathVariable UUID instanceAccessKey,
                           @Nullable @RequestParam(value = "version", required = false) Integer version,
@@ -736,13 +736,13 @@ public class FormTriggerControllerV1 {
 
     @Nonnull
     private ResolvedFormTriggerContext resolveFormTriggerContext(@Nullable Jwt jwt,
-                                                                 @Nonnull UUID processAccessKey,
+                                                                 @Nonnull String processSlug,
                                                                  @Nonnull String formSlug,
                                                                  @Nullable String testClaimAccessKey,
                                                                  @Nullable Integer processVersion) throws ResponseException {
         var execUser = getExecUser(jwt);
-        var process = getProcessEntity(processAccessKey);
-        var processVersionEntity = getProcessVersionEntity(testClaimAccessKey, processVersion, process);
+        var process = getProcessEntity(processSlug);
+        var processVersionEntity = getProcessVersionEntity(testClaimAccessKey, processVersion, process, execUser);
         var node = getProcessNodeEntity(formSlug, process, processVersionEntity);
         var provider = getProvider(node);
         var config = getConfigurationDetails(node, provider, execUser);
@@ -846,12 +846,19 @@ public class FormTriggerControllerV1 {
     @Nonnull
     private ProcessVersionEntity getProcessVersionEntity(@Nullable String testClaimAccessKey,
                                                          @Nullable Integer processVersion,
-                                                         ProcessEntity process) throws ResponseException {
+                                                         ProcessEntity process,
+                                                         @Nullable UserEntity execUser) throws ResponseException {
         var processVersionFilter = ProcessVersionFilter
                 .create()
                 .setProcessId(process.getId());
 
         if (processVersion != null) {
+            // Explicit version access is only for authenticated staff tooling.
+            // Public citizen URLs must resolve through the published version or a test claim.
+            if (execUser == null) {
+                throw ResponseException.notFound();
+            }
+
             processVersionFilter
                     .setProcessVersion(processVersion);
         } else if (testClaimAccessKey != null) {
@@ -870,9 +877,9 @@ public class FormTriggerControllerV1 {
     }
 
     @Nonnull
-    private ProcessEntity getProcessEntity(@Nonnull UUID processAccessKey) throws ResponseException {
+    private ProcessEntity getProcessEntity(@Nonnull String processSlug) throws ResponseException {
         return processService
-                .retrieveByAccessKey(processAccessKey)
+                .retrieveBySlugOrHistory(processSlug)
                 .orElseThrow(ResponseException::notFound);
     }
 

--- a/src/main/java/de/aivot/GoverBackend/plugins/form/v1/nodes/FormTriggerListControllerV1.java
+++ b/src/main/java/de/aivot/GoverBackend/plugins/form/v1/nodes/FormTriggerListControllerV1.java
@@ -78,7 +78,7 @@ public class FormTriggerListControllerV1 {
     }
 
 
-    @GetMapping("/api/public/forms/v1/")
+    @GetMapping("/api/public/forms/")
     public Page<FormListItem> listPublic(
             @Nonnull @ParameterObject @PageableDefault Pageable pageable,
             @Nonnull @ParameterObject @Valid ProcessNodeFilter filter

--- a/src/main/java/de/aivot/GoverBackend/plugins/form/v1/nodes/FormTriggerNodeV1.java
+++ b/src/main/java/de/aivot/GoverBackend/plugins/form/v1/nodes/FormTriggerNodeV1.java
@@ -16,7 +16,6 @@ import de.aivot.GoverBackend.elements.utils.ElementPOJOMapper;
 import de.aivot.GoverBackend.elements.utils.ElementStreamUtils;
 import de.aivot.GoverBackend.enums.ElementType;
 import de.aivot.GoverBackend.lib.exceptions.ResponseException;
-import de.aivot.GoverBackend.models.config.GoverConfig;
 import de.aivot.GoverBackend.plugin.models.PluginComponent;
 import de.aivot.GoverBackend.plugins.form.FormPlugin;
 import de.aivot.GoverBackend.plugins.form.v1.services.FormLayoutCleanerService;
@@ -31,6 +30,7 @@ import de.aivot.GoverBackend.process.models.processContext.ProcessNodeDefinition
 import de.aivot.GoverBackend.process.models.processContext.ProcessNodeDefinitionTestingLayoutContext;
 import de.aivot.GoverBackend.process.models.processContext.ProcessNodeExecutionInitContext;
 import de.aivot.GoverBackend.process.repositories.ProcessNodeRepository;
+import de.aivot.GoverBackend.process.services.PublicUrlService;
 import de.aivot.GoverBackend.utils.StringUtils;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
@@ -47,12 +47,12 @@ public class FormTriggerNodeV1 implements ProcessNodeDefinition<FormTriggerConfi
     public static final String DATA_KEY_UNMAPPED = "unmapped";
     public static final String DATA_KEY_ATTACHMENTS = "attachments";
 
-    private final GoverConfig goverConfig;
+    private final PublicUrlService publicUrlService;
     private final ProcessNodeRepository processNodeRepository;
 
-    public FormTriggerNodeV1(GoverConfig goverConfig,
+    public FormTriggerNodeV1(PublicUrlService publicUrlService,
                              ProcessNodeRepository processNodeRepository) {
-        this.goverConfig = goverConfig;
+        this.publicUrlService = publicUrlService;
         this.processNodeRepository = processNodeRepository;
     }
 
@@ -157,11 +157,11 @@ public class FormTriggerNodeV1 implements ProcessNodeDefinition<FormTriggerConfi
                 .findChild(FormTriggerConfigV1.FORM_SLUG, TextInputElement.class)
                 .ifPresent(field -> {
                     var pattern = new TextInputElementPattern()
-                            .setRegex("^[a-zA-Z0-9-]+$")
-                            .setMessage("Der Webhook-Slug darf nur aus Buchstaben, Zahlen und Bindestrichen bestehen.");
+                            .setRegex("^[a-z0-9-]+$")
+                            .setMessage("Das URL-Segment des Formulars darf nur aus Kleinbuchstaben, Zahlen und Bindestrichen bestehen.");
                     field.setPattern(pattern);
 
-                    field.setPrefix(goverConfig.createUrlWithTrailingSlash("…/forms/…"));
+                    field.setPrefix(publicUrlService.createProcessNamespaceDisplayPrefix());
                 });
 
         config
@@ -178,12 +178,10 @@ public class FormTriggerNodeV1 implements ProcessNodeDefinition<FormTriggerConfi
     @Nullable
     @Override
     public GroupLayoutElement getTestingLayout(@Nonnull ProcessNodeDefinitionTestingLayoutContext<FormTriggerConfigV1> context) throws ResponseException {
-        var link = goverConfig
-                .createUrl(
-                        "/forms/v1/",
-                        context.processDefinition().getAccessKey().toString(),
-                        context.configuration().formSlug
-                ) + "?" + FormTriggerControllerV1.TEST_CLAIM_QUERY_PARAM + "=" + context.testClaim().getAccessKey();
+        var link = publicUrlService.createPublicFormUrl(
+                context.processDefinition(),
+                context.configuration().formSlug
+        ) + "?" + FormTriggerControllerV1.TEST_CLAIM_QUERY_PARAM + "=" + context.testClaim().getAccessKey();
 
         var layout = new GroupLayoutElement();
         layout.setId("testing");
@@ -207,6 +205,13 @@ public class FormTriggerNodeV1 implements ProcessNodeDefinition<FormTriggerConfi
         var formSlug = configuration.formSlug;
 
         if (StringUtils.isNotNullOrEmpty(formSlug)) {
+            if (!formSlug.matches("^[a-z0-9-]+$")) {
+                errors.put(
+                        FormTriggerConfigV1.FORM_SLUG,
+                        "Das URL-Segment des Formulars darf nur aus Kleinbuchstaben, Zahlen und Bindestrichen bestehen."
+                );
+            }
+
             var duplicateNodeFilter = ProcessNodeFilter
                     .create()
                     .setNotId(processNodeEntity.getId())
@@ -216,9 +221,9 @@ public class FormTriggerNodeV1 implements ProcessNodeDefinition<FormTriggerConfi
                     .addConfigEquals(FormTriggerConfigV1.FORM_SLUG, formSlug);
 
             if (processNodeRepository.exists(duplicateNodeFilter.build())) {
-                errors.put(
+                errors.putIfAbsent(
                         FormTriggerConfigV1.FORM_SLUG,
-                        "Die Formular-URL wird in dieser Prozessversion bereits von einem anderen Formulareingang verwendet."
+                        "Das URL-Segment des Formulars wird in dieser Prozessversion bereits von einem anderen Formulareingang verwendet."
                 );
             }
         }

--- a/src/main/java/de/aivot/GoverBackend/plugins/form/v1/nodes/FormTriggerUtilsControllerV1.java
+++ b/src/main/java/de/aivot/GoverBackend/plugins/form/v1/nodes/FormTriggerUtilsControllerV1.java
@@ -4,7 +4,6 @@ import de.aivot.GoverBackend.department.entities.VDepartmentShadowedEntity;
 import de.aivot.GoverBackend.department.services.VDepartmentShadowedService;
 import de.aivot.GoverBackend.elements.models.elements.layout.FormLayoutElement;
 import de.aivot.GoverBackend.lib.exceptions.ResponseException;
-import de.aivot.GoverBackend.models.config.GoverConfig;
 import de.aivot.GoverBackend.openApi.OpenApiConfiguration;
 import de.aivot.GoverBackend.pdf.models.PrintableFormPdfData;
 import de.aivot.GoverBackend.permissions.services.PermissionService;
@@ -14,6 +13,7 @@ import de.aivot.GoverBackend.process.permissions.ProcessPermissionProvider;
 import de.aivot.GoverBackend.process.services.ProcessNodeDefinitionService;
 import de.aivot.GoverBackend.process.services.ProcessNodeService;
 import de.aivot.GoverBackend.process.services.ProcessService;
+import de.aivot.GoverBackend.process.services.PublicUrlService;
 import de.aivot.GoverBackend.services.PdfService;
 import de.aivot.GoverBackend.system.services.SystemService;
 import de.aivot.GoverBackend.theme.entities.ThemeEntity;
@@ -58,7 +58,7 @@ import java.util.List;
 )
 @SecurityRequirement(name = OpenApiConfiguration.Security)
 public class FormTriggerUtilsControllerV1 {
-    private final GoverConfig goverConfig;
+    private final PublicUrlService publicUrlService;
     private final UserService userService;
     private final PermissionService permissionService;
     private final ProcessService processService;
@@ -71,7 +71,7 @@ public class FormTriggerUtilsControllerV1 {
     private final FormTriggerNodeV1 formTriggerNodeV1;
 
     @Autowired
-    public FormTriggerUtilsControllerV1(GoverConfig goverConfig,
+    public FormTriggerUtilsControllerV1(PublicUrlService publicUrlService,
                                         UserService userService,
                                         PermissionService permissionService,
                                         ProcessService processService,
@@ -82,7 +82,7 @@ public class FormTriggerUtilsControllerV1 {
                                         SystemService systemService,
                                         PdfService pdfService,
                                         FormTriggerNodeV1 formTriggerNodeV1) {
-        this.goverConfig = goverConfig;
+        this.publicUrlService = publicUrlService;
         this.userService = userService;
         this.permissionService = permissionService;
         this.processService = processService;
@@ -197,7 +197,7 @@ public class FormTriggerUtilsControllerV1 {
     private String createPublicFormPath(@Nonnull ProcessEntity process,
                                         @Nonnull String formSlug,
                                         @Nonnull Integer processVersion) {
-        var publicUrl = goverConfig.createUrlWithTrailingSlash("/forms/v1/", process.getAccessKey(), formSlug);
+        var publicUrl = publicUrlService.createPublicFormUrl(process, formSlug);
         var rawPath = URI.create(publicUrl).getRawPath();
         return rawPath + "?version=" + processVersion;
     }

--- a/src/main/java/de/aivot/GoverBackend/process/controllers/ProcessController.java
+++ b/src/main/java/de/aivot/GoverBackend/process/controllers/ProcessController.java
@@ -35,6 +35,7 @@ import org.springframework.web.bind.annotation.*;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 
@@ -106,6 +107,37 @@ public class ProcessController {
                         execUser.getId(),
                         filter.build()
                 );
+    }
+
+    @GetMapping("slug-availability/")
+    @Operation(
+            summary = "Check Process Slug Availability",
+            description = "Check whether a public URL namespace can be used by a process definition."
+    )
+    public ProcessSlugAvailabilityResponse checkSlugAvailability(
+            @Nullable @AuthenticationPrincipal Jwt jwt,
+            @Nonnull @RequestParam String slug,
+            @Nullable @RequestParam(required = false) Integer processId
+    ) throws ResponseException {
+        var execUser = userService
+                .fromJWT(jwt)
+                .orElseThrow(ResponseException::unauthorized);
+
+        if (processId != null) {
+            var process = processDefinitionService
+                    .retrieve(processId)
+                    .orElseThrow(ResponseException::notFound);
+
+            permissionService.testDepartmentPermission(
+                    execUser.getId(),
+                    process.getDepartmentId(),
+                    ProcessPermissionProvider.PROCESS_DEFINITION_UPDATE
+            );
+        }
+
+        return new ProcessSlugAvailabilityResponse(
+                processDefinitionService.isSlugAvailable(slug, processId)
+        );
     }
 
     @PostMapping("")
@@ -359,6 +391,71 @@ public class ProcessController {
         return result;
     }
 
+    @GetMapping("{id}/slug-history/")
+    @Operation(
+            summary = "List Process Slug History",
+            description = "List previous public URL namespaces for a process definition. " +
+                    "Requires edit permissions for the process definition."
+    )
+    public List<ProcessSlugHistoryEntity> listSlugHistory(
+            @Nullable @AuthenticationPrincipal Jwt jwt,
+            @Nonnull @PathVariable Integer id
+    ) throws ResponseException {
+        var execUser = userService
+                .fromJWT(jwt)
+                .orElseThrow(ResponseException::unauthorized);
+
+        var process = processDefinitionService
+                .retrieve(id)
+                .orElseThrow(ResponseException::notFound);
+
+        permissionService.testDepartmentPermission(
+                execUser.getId(),
+                process.getDepartmentId(),
+                ProcessPermissionProvider.PROCESS_DEFINITION_UPDATE
+        );
+
+        return processDefinitionService.listSlugHistory(id);
+    }
+
+    @DeleteMapping("{id}/slug-history/")
+    @Operation(
+            summary = "Clear Process Slug History",
+            description = "Delete previous public URL namespaces for a process definition. " +
+                    "Requires edit permissions for the process definition."
+    )
+    public void clearSlugHistory(
+            @Nullable @AuthenticationPrincipal Jwt jwt,
+            @Nonnull @PathVariable Integer id
+    ) throws ResponseException {
+        var execUser = userService
+                .fromJWT(jwt)
+                .orElseThrow(ResponseException::unauthorized);
+
+        var process = processDefinitionService
+                .retrieve(id)
+                .orElseThrow(ResponseException::notFound);
+
+        permissionService.testDepartmentPermission(
+                execUser.getId(),
+                process.getDepartmentId(),
+                ProcessPermissionProvider.PROCESS_DEFINITION_UPDATE
+        );
+
+        processDefinitionService.clearSlugHistory(id);
+
+        auditService.create()
+                .withUser(execUser)
+                .withAuditAction(AuditAction.Update, ProcessEntity.class,
+                        process.getId(),
+                        "id"
+                ).withMessage(
+                        "Die Slug-Historie des Prozesses mit der ID %s wurde von der Mitarbeiter:in %s geleert.",
+                        StringUtils.quote(String.valueOf(process.getId())),
+                        StringUtils.quote(execUser.getFullName())
+                ).log();
+    }
+
     @DeleteMapping("{id}/")
     @Operation(
             summary = "Delete Process Definition",
@@ -393,8 +490,8 @@ public class ProcessController {
     @PutMapping("{id}/move/")
     @Operation(
             summary = "Move Process",
-            description = "Move a form to another department. " +
-                    "The user must be a super admin or have edit permission in the current developing department of the form."
+            description = "Move a process to another department. " +
+                    "The user must be a super admin or have edit permission in the current managing department of the process."
     )
     @SecurityRequirement(name = OpenApiConfiguration.Security)
     public ProcessEntity move(
@@ -412,6 +509,9 @@ public class ProcessController {
                 .retrieve(id)
                 .orElseThrow(ResponseException::notFound);
 
+        var existingMap = objectMapper
+                .convertValue(process, Map.class);
+
         // Check if the user has edit permission for the process in the original department
         permissionService.testDepartmentPermission(
                 user.getId(),
@@ -426,13 +526,29 @@ public class ProcessController {
                 ProcessPermissionProvider.PROCESS_DEFINITION_CREATE
         );
 
-        // Move the form to the target department
-        process.setDraftedVersion(targetDepartmentId);
+        // Moving a process changes only the managing department. Version pointers must remain untouched.
+        process.setDepartmentId(targetDepartmentId);
 
-        // Create a revision for the form
-        return processDefinitionService.update(process.getId(), process);
+        // Persist through the regular update path so process metadata handling stays centralized.
+        var result = processDefinitionService.update(process.getId(), process);
 
-        // TODO: Create revisions
+        var updatedMap = objectMapper
+                .convertValue(result, Map.class);
+
+        auditService.create()
+                .withUser(user)
+                .withAuditAction(AuditAction.Update, ProcessEntity.class,
+                        result.getId(),
+                        "id"
+                )
+                .withDiff(existingMap, updatedMap).withMessage(
+                        "Der Prozess mit der ID %s wurde von der Mitarbeiter:in %s an die Organisationseinheit mit der ID %s übertragen.",
+                        StringUtils.quote(String.valueOf(result.getId())),
+                        StringUtils.quote(user.getFullName()),
+                        StringUtils.quote(String.valueOf(targetDepartmentId))
+                ).log();
+
+        return result;
     }
 
 
@@ -606,5 +722,8 @@ public class ProcessController {
                 .log();
 
         return result;
+    }
+
+    public record ProcessSlugAvailabilityResponse(boolean available) {
     }
 }

--- a/src/main/java/de/aivot/GoverBackend/process/controllers/ProcessVersionController.java
+++ b/src/main/java/de/aivot/GoverBackend/process/controllers/ProcessVersionController.java
@@ -189,16 +189,15 @@ public class ProcessVersionController {
                 .orElseThrow(ResponseException::notFound);
         var existingMap = AuditLogPayload.toMap(existing);
 
-        // Check department permission for the process definition this version belongs to
-        var department = departmentService
+        var processDefinition = processDefinitionService
                 .retrieve(existing.getProcessId())
                 .orElseThrow(ResponseException::badRequest);
 
         permissionService
                 .testDepartmentPermission(
                         execUser.getId(),
-                        department.getId(),
-                        ProcessPermissionProvider.PROCESS_DEFINITION_CREATE
+                        processDefinition.getDepartmentId(),
+                        ProcessPermissionProvider.PROCESS_DEFINITION_UPDATE
                 );
 
         updateDTO.setProcessId(existing.getProcessId());
@@ -295,16 +294,20 @@ public class ProcessVersionController {
                 .fromJWT(jwt)
                 .orElseThrow(ResponseException::unauthorized);
 
-        permissionService.testDepartmentPermission(
-                user.getId(),
-                processDefinitionId,
-                ProcessPermissionProvider.PROCESS_DEFINITION_PUBLISH_LOCAL
-        );
-
         var versionId = ProcessVersionEntityId.of(processDefinitionId, processDefinitionVersion);
         var version = processDefinitionVersionService
                 .retrieve(versionId)
                 .orElseThrow(ResponseException::notFound);
+
+        var processDefinition = processDefinitionService
+                .retrieve(version.getProcessId())
+                .orElseThrow(ResponseException::badRequest);
+
+        permissionService.testDepartmentPermission(
+                user.getId(),
+                processDefinition.getDepartmentId(),
+                ProcessPermissionProvider.PROCESS_DEFINITION_PUBLISH_LOCAL
+        );
 
         var hasErrors = processDefinitionVersionService
                 .validate(version)
@@ -338,16 +341,20 @@ public class ProcessVersionController {
                 .fromJWT(jwt)
                 .orElseThrow(ResponseException::unauthorized);
 
-        permissionService.testDepartmentPermission(
-                user.getId(),
-                processDefinitionId,
-                ProcessPermissionProvider.PROCESS_DEFINITION_PUBLISH_LOCAL
-        );
-
         var versionId = ProcessVersionEntityId.of(processDefinitionId, processDefinitionVersion);
         var version = processDefinitionVersionService
                 .retrieve(versionId)
                 .orElseThrow(ResponseException::notFound);
+
+        var processDefinition = processDefinitionService
+                .retrieve(version.getProcessId())
+                .orElseThrow(ResponseException::badRequest);
+
+        permissionService.testDepartmentPermission(
+                user.getId(),
+                processDefinition.getDepartmentId(),
+                ProcessPermissionProvider.PROCESS_DEFINITION_PUBLISH_LOCAL
+        );
 
         if (version.getStatus() != ProcessVersionStatus.Published) {
             throw ResponseException.conflict("Es kann nur eine veröffentlichte Prozessdefinition zurückgezogen werden.");

--- a/src/main/java/de/aivot/GoverBackend/process/entities/ProcessEntity.java
+++ b/src/main/java/de/aivot/GoverBackend/process/entities/ProcessEntity.java
@@ -5,6 +5,7 @@ import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import org.hibernate.validator.constraints.Length;
 
 import java.time.Instant;
@@ -21,9 +22,9 @@ public class ProcessEntity {
     private Integer id;
 
     @Nonnull
-    @NotNull(message = "Der interne Title der Prozessdefinition darf nicht null sein.")
-    @NotBlank(message = "Der interne Title der Prozessdefinition darf nicht leer sein.")
-    @Length(min=3, max = 96, message = "Der interne Title der Prozessdefinition muss zwischen 3 und 96 Zeichen lang sein.")
+    @NotNull(message = "Der interne Titel der Prozessdefinition darf nicht null sein.")
+    @NotBlank(message = "Der interne Titel der Prozessdefinition darf nicht leer sein.")
+    @Length(min=3, max = 96, message = "Der interne Titel der Prozessdefinition muss zwischen 3 und 96 Zeichen lang sein.")
     private String internalTitle;
 
     @Nonnull
@@ -33,6 +34,12 @@ public class ProcessEntity {
     @Nonnull
     @NotNull(message = "Die ID der Organisationseinheit darf nicht null sein.")
     private UUID accessKey;
+
+    @Nonnull
+    @NotBlank(message = "Der URL-Namespace des Prozesses darf nicht leer sein.")
+    @Pattern(regexp = "^[a-z0-9-]+$", message = "Der URL-Namespace des Prozesses darf nur aus Kleinbuchstaben, Zahlen und Bindestrichen bestehen.")
+    @Length(min = 3, max = 128, message = "Der URL-Namespace des Prozesses muss zwischen 3 und 128 Zeichen lang sein.")
+    private String slug;
 
     @Nonnull
     @NotNull(message = "Die Versionsanzahl darf nicht null sein.")
@@ -64,6 +71,7 @@ public class ProcessEntity {
                          @Nonnull String internalTitle,
                          @Nonnull Integer departmentId,
                          @Nonnull UUID accessKey,
+                         @Nonnull String slug,
                          @Nonnull Integer versionCount,
                          @Nullable Integer draftedVersion,
                          @Nullable Integer publishedVersion,
@@ -73,11 +81,35 @@ public class ProcessEntity {
         this.internalTitle = internalTitle;
         this.departmentId = departmentId;
         this.accessKey = accessKey;
+        this.slug = slug;
         this.versionCount = versionCount;
         this.draftedVersion = draftedVersion;
         this.publishedVersion = publishedVersion;
         this.created = created;
         this.updated = updated;
+    }
+
+    public ProcessEntity(@Nonnull Integer id,
+                         @Nonnull String internalTitle,
+                         @Nonnull Integer departmentId,
+                         @Nonnull UUID accessKey,
+                         @Nonnull Integer versionCount,
+                         @Nullable Integer draftedVersion,
+                         @Nullable Integer publishedVersion,
+                         @Nonnull Instant created,
+                         @Nonnull Instant updated) {
+        this(
+                id,
+                internalTitle,
+                departmentId,
+                accessKey,
+                "process-" + id,
+                versionCount,
+                draftedVersion,
+                publishedVersion,
+                created,
+                updated
+        );
     }
 
     // endregion
@@ -186,6 +218,16 @@ public class ProcessEntity {
 
     public ProcessEntity setAccessKey(@Nonnull UUID accessKey) {
         this.accessKey = accessKey;
+        return this;
+    }
+
+    @Nonnull
+    public String getSlug() {
+        return slug;
+    }
+
+    public ProcessEntity setSlug(@Nonnull String slug) {
+        this.slug = slug;
         return this;
     }
 

--- a/src/main/java/de/aivot/GoverBackend/process/entities/ProcessInstanceEntity.java
+++ b/src/main/java/de/aivot/GoverBackend/process/entities/ProcessInstanceEntity.java
@@ -29,7 +29,7 @@ public class ProcessInstanceEntity {
     private Long id;
 
     @Nonnull
-    @NotNull(message = "Das Aktenzeichen darf nicht null sein.")
+    @NotNull(message = "Der Vorgangsschlüssel darf nicht null sein.")
     private String caseNumber;
 
     @Nonnull

--- a/src/main/java/de/aivot/GoverBackend/process/entities/ProcessSlugHistoryEntity.java
+++ b/src/main/java/de/aivot/GoverBackend/process/entities/ProcessSlugHistoryEntity.java
@@ -1,0 +1,70 @@
+package de.aivot.GoverBackend.process.entities;
+
+import jakarta.annotation.Nonnull;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "process_slug_history")
+public class ProcessSlugHistoryEntity {
+    @Id
+    @Nonnull
+    private String slug;
+
+    @Nonnull
+    private Integer processId;
+
+    @Nonnull
+    private Instant created;
+
+    public ProcessSlugHistoryEntity() {
+        slug = "";
+        processId = 0;
+        created = Instant.now();
+    }
+
+    public ProcessSlugHistoryEntity(@Nonnull String slug, @Nonnull Integer processId) {
+        this.slug = slug;
+        this.processId = processId;
+        created = Instant.now();
+    }
+
+    public ProcessSlugHistoryEntity(@Nonnull String slug, @Nonnull Integer processId, @Nonnull Instant created) {
+        this.slug = slug;
+        this.processId = processId;
+        this.created = created;
+    }
+
+    @Nonnull
+    public String getSlug() {
+        return slug;
+    }
+
+    public ProcessSlugHistoryEntity setSlug(@Nonnull String slug) {
+        this.slug = slug;
+        return this;
+    }
+
+    @Nonnull
+    public Integer getProcessId() {
+        return processId;
+    }
+
+    public ProcessSlugHistoryEntity setProcessId(@Nonnull Integer processId) {
+        this.processId = processId;
+        return this;
+    }
+
+    @Nonnull
+    public Instant getCreated() {
+        return created;
+    }
+
+    public ProcessSlugHistoryEntity setCreated(@Nonnull Instant created) {
+        this.created = created;
+        return this;
+    }
+}

--- a/src/main/java/de/aivot/GoverBackend/process/filters/ProcessFilter.java
+++ b/src/main/java/de/aivot/GoverBackend/process/filters/ProcessFilter.java
@@ -13,6 +13,7 @@ public class ProcessFilter implements Filter<ProcessEntity> {
     private Integer departmentId;
     private Integer departmentIdNot;
     private UUID accessKey;
+    private String slug;
 
     private Boolean isDrafted;
     private Boolean isPublished;
@@ -30,7 +31,8 @@ public class ProcessFilter implements Filter<ProcessEntity> {
                 .withContains("internalTitle", internalTitle)
                 .withEquals("departmentId", departmentId)
                 .withNotEquals("departmentId", departmentIdNot)
-                .withEquals("accessKey", accessKey);
+                .withEquals("accessKey", accessKey)
+                .withEquals("slug", slug);
 
         if (Boolean.TRUE.equals(isDrafted)) {
             builder.withNotNull("draftedVersion");
@@ -80,6 +82,11 @@ public class ProcessFilter implements Filter<ProcessEntity> {
         return this;
     }
 
+    public ProcessFilter setSlug(String slug) {
+        this.slug = slug;
+        return this;
+    }
+
     public ProcessFilter setIsDrafted(Boolean drafted) {
         isDrafted = drafted;
         return this;
@@ -95,4 +102,3 @@ public class ProcessFilter implements Filter<ProcessEntity> {
         return this;
     }
 }
-

--- a/src/main/java/de/aivot/GoverBackend/process/repositories/ProcessRepository.java
+++ b/src/main/java/de/aivot/GoverBackend/process/repositories/ProcessRepository.java
@@ -20,4 +20,10 @@ public interface ProcessRepository extends JpaRepository<ProcessEntity, Integer>
                                               @Nonnull @Param("permission") String permission);
 
     Optional<ProcessEntity> findByAccessKey(UUID accessKey);
+
+    Optional<ProcessEntity> findBySlug(@Nonnull String slug);
+
+    boolean existsBySlug(@Nonnull String slug);
+
+    boolean existsBySlugAndIdIsNot(@Nonnull String slug, @Nonnull Integer id);
 }

--- a/src/main/java/de/aivot/GoverBackend/process/repositories/ProcessSlugHistoryRepository.java
+++ b/src/main/java/de/aivot/GoverBackend/process/repositories/ProcessSlugHistoryRepository.java
@@ -1,0 +1,19 @@
+package de.aivot.GoverBackend.process.repositories;
+
+import de.aivot.GoverBackend.process.entities.ProcessSlugHistoryEntity;
+import jakarta.annotation.Nonnull;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProcessSlugHistoryRepository extends JpaRepository<ProcessSlugHistoryEntity, String>, JpaSpecificationExecutor<ProcessSlugHistoryEntity> {
+    boolean existsBySlugAndProcessIdIsNot(@Nonnull String slug, @Nonnull Integer processId);
+
+    Optional<ProcessSlugHistoryEntity> findBySlug(@Nonnull String slug);
+
+    List<ProcessSlugHistoryEntity> findAllByProcessIdOrderByCreatedDesc(@Nonnull Integer processId);
+
+    void deleteAllByProcessId(@Nonnull Integer processId);
+}

--- a/src/main/java/de/aivot/GoverBackend/process/services/CaseNumberGeneratorService.java
+++ b/src/main/java/de/aivot/GoverBackend/process/services/CaseNumberGeneratorService.java
@@ -105,7 +105,7 @@ public class CaseNumberGeneratorService {
 
         if (caseNumber.codePointCount(0, caseNumber.length()) > MAX_CASE_NUMBER_LENGTH) {
             throw ResponseException.internalServerError(
-                    "Das erzeugte Aktenzeichen überschreitet unerwartet das zulässige Limit von %d Zeichen.",
+                    "Der erzeugte Vorgangsschlüssel überschreitet unerwartet das zulässige Limit von %d Zeichen.",
                     MAX_CASE_NUMBER_LENGTH
             );
         }
@@ -116,7 +116,7 @@ public class CaseNumberGeneratorService {
     @Nonnull
     private ParsedCaseNumberTemplate parseTemplate(@Nonnull String caseNumberTemplate) throws ResponseException {
         if (caseNumberTemplate.isBlank()) {
-            throw ResponseException.badRequest("Die Aktenzeichenvorlage darf nicht leer sein.");
+            throw ResponseException.badRequest("Die Vorgangsschlüssel-Formatvorlage darf nicht leer sein.");
         }
 
         var incrementMatcher = CASE_NUMBER_INCREMENT_PATTERN.matcher(caseNumberTemplate);
@@ -160,7 +160,7 @@ public class CaseNumberGeneratorService {
             int codePoint = caseNumberTemplate.codePointAt(index);
             if (codePoint == '%') {
                 throw ResponseException.badRequest(
-                        "Die Aktenzeichenvorlage enthält einen unbekannten Platzhalter an Position %d. Unterstützt werden %s.",
+                        "Die Vorgangsschlüssel-Formatvorlage enthält einen unbekannten Platzhalter an Position %d. Unterstützt werden %s.",
                         index + 1,
                         SUPPORTED_PLACEHOLDERS
                 );
@@ -172,13 +172,13 @@ public class CaseNumberGeneratorService {
 
         if (incrementMatchCount != 1) {
             throw ResponseException.badRequest(
-                    "Die Aktenzeichenvorlage muss genau einen Inkrement-Platzhalter im Format %I(n) enthalten."
+                    "Die Vorgangsschlüssel-Formatvorlage muss genau einen Inkrement-Platzhalter im Format %I(n) enthalten."
             );
         }
 
         if (renderedLength > MAX_CASE_NUMBER_LENGTH) {
             throw ResponseException.badRequest(
-                    "Das erzeugte Aktenzeichen würde das Limit von %d Zeichen überschreiten.",
+                    "Der erzeugte Vorgangsschlüssel würde das Limit von %d Zeichen überschreiten.",
                     MAX_CASE_NUMBER_LENGTH
             );
         }
@@ -195,7 +195,7 @@ public class CaseNumberGeneratorService {
         var padding = Integer.parseInt(incrementMatcher.group(1));
         if (padding < CASE_NUMBER_PADDING_MIN || padding > CASE_NUMBER_PADDING_MAX) {
             throw ResponseException.badRequest(
-                    "Die Inkrement-Breite in der Aktenzeichenvorlage muss zwischen %d und %d Stellen liegen.",
+                    "Die Inkrement-Breite in der Vorgangsschlüssel-Formatvorlage muss zwischen %d und %d Stellen liegen.",
                     CASE_NUMBER_PADDING_MIN,
                     CASE_NUMBER_PADDING_MAX
             );

--- a/src/main/java/de/aivot/GoverBackend/process/services/ProcessInstanceService.java
+++ b/src/main/java/de/aivot/GoverBackend/process/services/ProcessInstanceService.java
@@ -134,7 +134,7 @@ public class ProcessInstanceService implements EntityService<ProcessInstanceEnti
             } catch (DataIntegrityViolationException e) {
                 if (processInstanceRepository.existsByCaseNumber(entity.getCaseNumber())) {
                     if (attempt == MAX_CASE_NUMBER_GENERATION_ATTEMPTS) {
-                        throw ResponseException.conflict("Es konnte kein eindeutiges Aktenzeichen erzeugt werden. Bitte versuchen Sie es erneut.");
+                        throw ResponseException.conflict("Es konnte kein eindeutiger Vorgangsschlüssel erzeugt werden. Bitte versuchen Sie es erneut.");
                     }
                     continue;
                 }
@@ -143,6 +143,6 @@ public class ProcessInstanceService implements EntityService<ProcessInstanceEnti
             }
         }
 
-        throw ResponseException.conflict("Es konnte kein eindeutiges Aktenzeichen erzeugt werden. Bitte versuchen Sie es erneut.");
+        throw ResponseException.conflict("Es konnte kein eindeutiger Vorgangsschlüssel erzeugt werden. Bitte versuchen Sie es erneut.");
     }
 }

--- a/src/main/java/de/aivot/GoverBackend/process/services/ProcessService.java
+++ b/src/main/java/de/aivot/GoverBackend/process/services/ProcessService.java
@@ -5,8 +5,11 @@ import de.aivot.GoverBackend.lib.models.Filter;
 import de.aivot.GoverBackend.lib.services.EntityService;
 import de.aivot.GoverBackend.permissions.services.PermissionService;
 import de.aivot.GoverBackend.process.entities.ProcessEntity;
+import de.aivot.GoverBackend.process.entities.ProcessSlugHistoryEntity;
 import de.aivot.GoverBackend.process.permissions.ProcessPermissionProvider;
 import de.aivot.GoverBackend.process.repositories.ProcessRepository;
+import de.aivot.GoverBackend.process.repositories.ProcessSlugHistoryRepository;
+import de.aivot.GoverBackend.utils.StringUtils;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.criteria.Predicate;
@@ -15,22 +18,29 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
 @Service
 public class ProcessService implements EntityService<ProcessEntity, Integer> {
+    private static final int MAX_SLUG_LENGTH = 128;
 
     private final ProcessRepository processDefinitionRepository;
+    private final ProcessSlugHistoryRepository processSlugHistoryRepository;
     private final PermissionService permissionService;
 
     @Autowired
     public ProcessService(ProcessRepository processDefinitionRepository,
+                          ProcessSlugHistoryRepository processSlugHistoryRepository,
                           PermissionService permissionService) {
         this.processDefinitionRepository = processDefinitionRepository;
+        this.processSlugHistoryRepository = processSlugHistoryRepository;
         this.permissionService = permissionService;
     }
 
@@ -39,6 +49,11 @@ public class ProcessService implements EntityService<ProcessEntity, Integer> {
     public ProcessEntity create(@Nonnull ProcessEntity entity) throws ResponseException {
         entity.setId(null);
         entity.setAccessKey(UUID.randomUUID());
+
+        var slug = normalizeAndValidateSlug(entity.getSlug());
+        validateSlugIsAvailable(slug, null);
+        entity.setSlug(slug);
+
         return processDefinitionRepository.save(entity);
     }
 
@@ -119,8 +134,24 @@ public class ProcessService implements EntityService<ProcessEntity, Integer> {
     public ProcessEntity performUpdate(@Nonnull Integer id,
                                        @Nonnull ProcessEntity entity,
                                        @Nonnull ProcessEntity existingEntity) throws ResponseException {
+        var previousSlug = existingEntity.getSlug();
+        var updatedSlug = normalizeAndValidateSlug(entity.getSlug());
+
+        validateSlugIsAvailable(updatedSlug, existingEntity.getId());
+
+        if (StringUtils.isNotNullOrEmpty(previousSlug) && !Objects.equals(previousSlug, updatedSlug)) {
+            if (processSlugHistoryRepository.existsById(updatedSlug)) {
+                processSlugHistoryRepository.deleteById(updatedSlug);
+            }
+
+            // Process slugs are external entry points. Keep the old namespace as an alias
+            // so published links survive process-level slug changes.
+            processSlugHistoryRepository.save(new ProcessSlugHistoryEntity(previousSlug, existingEntity.getId()));
+        }
+
         existingEntity.setInternalTitle(entity.getInternalTitle());
         existingEntity.setDepartmentId(entity.getDepartmentId());
+        existingEntity.setSlug(updatedSlug);
         return processDefinitionRepository.save(existingEntity);
     }
 
@@ -132,5 +163,101 @@ public class ProcessService implements EntityService<ProcessEntity, Integer> {
     public Optional<ProcessEntity> retrieveByAccessKey(UUID processAccessKey) throws ResponseException {
         return processDefinitionRepository
                 .findByAccessKey(processAccessKey);
+    }
+
+    public Optional<ProcessEntity> retrieveBySlug(@Nonnull String slug) throws ResponseException {
+        var normalizedSlug = normalizeSlug(slug);
+        return processDefinitionRepository
+                .findBySlug(normalizedSlug);
+    }
+
+    public Optional<ProcessEntity> retrieveBySlugOrHistory(@Nonnull String slug) throws ResponseException {
+        var normalizedSlug = normalizeSlug(slug);
+        var process = processDefinitionRepository.findBySlug(normalizedSlug);
+        if (process.isPresent()) {
+            return process;
+        }
+
+        return processSlugHistoryRepository
+                .findBySlug(normalizedSlug)
+                .flatMap(history -> processDefinitionRepository.findById(history.getProcessId()));
+    }
+
+    public List<ProcessSlugHistoryEntity> listSlugHistory(@Nonnull Integer processId) throws ResponseException {
+        if (!processDefinitionRepository.existsById(processId)) {
+            throw ResponseException.notFound();
+        }
+
+        return processSlugHistoryRepository.findAllByProcessIdOrderByCreatedDesc(processId);
+    }
+
+    @Transactional
+    public void clearSlugHistory(@Nonnull Integer processId) throws ResponseException {
+        if (!processDefinitionRepository.existsById(processId)) {
+            throw ResponseException.notFound();
+        }
+
+        // Clearing history intentionally releases former public namespaces for reuse by other processes.
+        processSlugHistoryRepository.deleteAllByProcessId(processId);
+    }
+
+    public boolean isSlugAvailable(@Nonnull String slug,
+                                   @Nullable Integer processId) throws ResponseException {
+        var normalizedSlug = normalizeAndValidateSlug(slug);
+
+        if (processId == null) {
+            return !processDefinitionRepository.existsBySlug(normalizedSlug) &&
+                    !processSlugHistoryRepository.existsById(normalizedSlug);
+        }
+
+        return !processDefinitionRepository.existsBySlugAndIdIsNot(normalizedSlug, processId) &&
+                !processSlugHistoryRepository.existsBySlugAndProcessIdIsNot(normalizedSlug, processId);
+    }
+
+    @Nonnull
+    private String normalizeAndValidateSlug(@Nullable String slug) throws ResponseException {
+        if (StringUtils.isNullOrEmpty(slug)) {
+            throw ResponseException.badRequest("Der URL-Namespace des Prozesses darf nicht leer sein.");
+        }
+
+        var normalizedSlug = normalizeSlug(slug);
+
+        if (normalizedSlug.length() < 3 || normalizedSlug.length() > MAX_SLUG_LENGTH) {
+            throw ResponseException.badRequest("Der URL-Namespace des Prozesses muss zwischen 3 und 128 Zeichen lang sein.");
+        }
+
+        if (!normalizedSlug.matches("^[a-z0-9-]+$")) {
+            throw ResponseException.badRequest("Der URL-Namespace des Prozesses darf nur aus Kleinbuchstaben, Zahlen und Bindestrichen bestehen.");
+        }
+
+        return normalizedSlug;
+    }
+
+    @Nonnull
+    private String normalizeSlug(@Nonnull String slug) {
+        return slug.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private void validateSlugIsAvailable(@Nonnull String slug,
+                                         @Nullable Integer processId) throws ResponseException {
+        if (processId == null) {
+            if (processDefinitionRepository.existsBySlug(slug)) {
+                throw ResponseException.conflict("Es existiert bereits ein Prozess mit diesem URL-Namespace.");
+            }
+
+            if (processSlugHistoryRepository.existsById(slug)) {
+                throw ResponseException.conflict("Es existiert bereits ein Prozess, der diesen URL-Namespace zuvor verwendet hat.");
+            }
+
+            return;
+        }
+
+        if (processDefinitionRepository.existsBySlugAndIdIsNot(slug, processId)) {
+            throw ResponseException.conflict("Es existiert bereits ein Prozess mit diesem URL-Namespace.");
+        }
+
+        if (processSlugHistoryRepository.existsBySlugAndProcessIdIsNot(slug, processId)) {
+            throw ResponseException.conflict("Es existiert bereits ein Prozess, der diesen URL-Namespace zuvor verwendet hat.");
+        }
     }
 }

--- a/src/main/java/de/aivot/GoverBackend/process/services/PublicUrlService.java
+++ b/src/main/java/de/aivot/GoverBackend/process/services/PublicUrlService.java
@@ -1,0 +1,69 @@
+package de.aivot.GoverBackend.process.services;
+
+import de.aivot.GoverBackend.models.config.GoverConfig;
+import de.aivot.GoverBackend.process.entities.ProcessEntity;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PublicUrlService {
+    private final GoverConfig goverConfig;
+
+    @Autowired
+    public PublicUrlService(GoverConfig goverConfig) {
+        this.goverConfig = goverConfig;
+    }
+
+    @Nonnull
+    public String createCustomerPageUrl(@Nonnull String elementType,
+                                        @Nonnull String processSlug,
+                                        @Nullable String elementSlug) {
+        return goverConfig.createUrlWithTrailingSlash(
+                "/" + elementType,
+                processSlug,
+                elementSlug
+        );
+    }
+
+    @Nonnull
+    public String createPublicApiUrl(@Nonnull String elementType,
+                                     @Nonnull String processSlug,
+                                     @Nullable String elementSlug,
+                                     @Nullable Object... additionalPathSegments) {
+        if (additionalPathSegments == null) {
+            additionalPathSegments = new Object[0];
+        }
+
+        var segments = new Object[3 + additionalPathSegments.length];
+        segments[0] = elementType;
+        segments[1] = processSlug;
+        segments[2] = elementSlug;
+        System.arraycopy(additionalPathSegments, 0, segments, 3, additionalPathSegments.length);
+
+        return goverConfig.createUrlWithTrailingSlash(
+                "/api/public",
+                segments
+        );
+    }
+
+    @Nonnull
+    public String createPublicFormUrl(@Nonnull ProcessEntity process,
+                                      @Nullable String formSlug) {
+        return createCustomerPageUrl("form", process.getSlug(), formSlug);
+    }
+
+    @Nonnull
+    public String createWebhookUrl(@Nonnull ProcessEntity process,
+                                   @Nullable String webhookSlug,
+                                   @Nullable Object... additionalPathSegments) {
+        return createPublicApiUrl("webhook", process.getSlug(), webhookSlug, additionalPathSegments);
+    }
+
+    @Nonnull
+    public String createProcessNamespaceDisplayPrefix() {
+        // Display-only placeholder for node configuration fields; public routing still uses full generated URLs.
+        return ".../prozess-namespace/";
+    }
+}

--- a/src/main/resources/db/migration/V29_3_0__process_slugs.sql
+++ b/src/main/resources/db/migration/V29_3_0__process_slugs.sql
@@ -1,0 +1,25 @@
+alter table processes
+    add column slug varchar(128);
+
+update processes
+set slug = 'process-' || id
+where slug is null;
+
+alter table processes
+    alter column slug set not null;
+
+alter table processes
+    add constraint processes_slug_unique unique (slug);
+
+create table process_slug_history
+(
+    slug       varchar(128) not null,
+    process_id int          not null,
+    created    timestamp with time zone not null default now(),
+
+    primary key (slug),
+    foreign key (process_id) references processes (id) on delete cascade
+);
+
+create index process_slug_history_process_id_idx
+    on process_slug_history (process_id);

--- a/src/test/java/de/aivot/GoverBackend/plugins/core/v1/nodes/triggers/webhook/WebhookTriggerControllerV1Test.java
+++ b/src/test/java/de/aivot/GoverBackend/plugins/core/v1/nodes/triggers/webhook/WebhookTriggerControllerV1Test.java
@@ -4,13 +4,11 @@ import de.aivot.GoverBackend.elements.models.ComputedElementStates;
 import de.aivot.GoverBackend.elements.models.DerivedRuntimeElementData;
 import de.aivot.GoverBackend.elements.models.EffectiveElementValues;
 import de.aivot.GoverBackend.lib.exceptions.ResponseException;
-import de.aivot.GoverBackend.permissions.services.PermissionService;
 import de.aivot.GoverBackend.process.entities.ProcessEntity;
 import de.aivot.GoverBackend.process.entities.ProcessInstanceEntity;
 import de.aivot.GoverBackend.process.entities.ProcessNodeEntity;
 import de.aivot.GoverBackend.process.models.ProcessNodeDefinition;
 import de.aivot.GoverBackend.process.repositories.ProcessNodeRepository;
-import de.aivot.GoverBackend.process.repositories.ProcessRepository;
 import de.aivot.GoverBackend.process.repositories.ProcessTestClaimRepository;
 import de.aivot.GoverBackend.process.services.ProcessInstanceAttachmentService;
 import de.aivot.GoverBackend.process.services.ProcessInstanceService;
@@ -46,7 +44,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class WebhookTriggerControllerV1Test {
-    private static final UUID ACCESS_KEY = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final String PROCESS_SLUG = "example-process";
 
     @Test
     void jsonEndpointShouldRemainPublic() throws NoSuchMethodException {
@@ -54,7 +52,7 @@ class WebhookTriggerControllerV1Test {
                 .getMethod(
                         "handleJson",
                         HttpServletRequest.class,
-                        UUID.class,
+                        String.class,
                         String.class,
                         Map.class,
                         String.class,
@@ -64,7 +62,7 @@ class WebhookTriggerControllerV1Test {
                 .getAnnotation(RequestMapping.class);
 
         assertNotNull(mapping);
-        assertArrayEquals(new String[]{"/api/public/webhooks/v1/{accessKey}/{slug}/json/"}, mapping.value());
+        assertArrayEquals(new String[]{"/api/public/webhook/{processSlug}/{slug}/json/"}, mapping.value());
         assertArrayEquals(new RequestMethod[]{RequestMethod.POST, RequestMethod.PUT, RequestMethod.PATCH}, mapping.method());
         assertArrayEquals(new String[]{MediaType.APPLICATION_JSON_VALUE}, mapping.consumes());
         assertArrayEquals(new String[]{MediaType.APPLICATION_JSON_VALUE}, mapping.produces());
@@ -76,7 +74,7 @@ class WebhookTriggerControllerV1Test {
                 .getMethod(
                         "handleWithoutBody",
                         HttpServletRequest.class,
-                        UUID.class,
+                        String.class,
                         String.class,
                         String.class,
                         String.class,
@@ -85,7 +83,7 @@ class WebhookTriggerControllerV1Test {
                 .getAnnotation(RequestMapping.class);
 
         assertNotNull(mapping);
-        assertArrayEquals(new String[]{"/api/public/webhooks/v1/{accessKey}/{slug}/"}, mapping.value());
+        assertArrayEquals(new String[]{"/api/public/webhook/{processSlug}/{slug}/"}, mapping.value());
         assertArrayEquals(new RequestMethod[]{RequestMethod.GET, RequestMethod.DELETE}, mapping.method());
         assertArrayEquals(new String[]{MediaType.APPLICATION_JSON_VALUE}, mapping.produces());
     }
@@ -104,7 +102,7 @@ class WebhookTriggerControllerV1Test {
                 ResponseException.class,
                 () -> fixture.controller().handleJson(
                         request,
-                        ACCESS_KEY,
+                        PROCESS_SLUG,
                         "example-slug",
                         Map.<String, Object>of("key", "value"),
                         null,
@@ -131,7 +129,7 @@ class WebhookTriggerControllerV1Test {
                 ResponseException.class,
                 () -> fixture.controller().handleXml(
                         request,
-                        ACCESS_KEY,
+                        PROCESS_SLUG,
                         "example-slug",
                         Map.<String, Object>of("key", "value"),
                         null,
@@ -158,7 +156,7 @@ class WebhookTriggerControllerV1Test {
 
         var response = fixture.controller().handleJson(
                 request,
-                ACCESS_KEY,
+                PROCESS_SLUG,
                 "example-slug",
                 Map.<String, Object>of("key", "value"),
                 null,
@@ -186,7 +184,7 @@ class WebhookTriggerControllerV1Test {
 
         var response = fixture.controller().handleFormData(
                 request,
-                ACCESS_KEY,
+                PROCESS_SLUG,
                 "example-slug",
                 null,
                 null,
@@ -214,7 +212,7 @@ class WebhookTriggerControllerV1Test {
 
         var response = fixture.controller().handleWithoutBody(
                 request,
-                ACCESS_KEY,
+                PROCESS_SLUG,
                 "example-slug",
                 null,
                 null,
@@ -230,7 +228,7 @@ class WebhookTriggerControllerV1Test {
                                                                  String requestBodyType) throws ResponseException {
         var process = new ProcessEntity()
                 .setId(1)
-                .setAccessKey(ACCESS_KEY);
+                .setSlug(PROCESS_SLUG);
 
         var node = new ProcessNodeEntity()
                 .setId(1)
@@ -275,9 +273,8 @@ class WebhookTriggerControllerV1Test {
         when(processNodeDefinitionService.getProcessNodeDefinition(any(ProcessNodeEntity.class)))
                 .thenReturn(Optional.of(processNodeDefinition));
 
-        var processRepository = mock(ProcessRepository.class);
-        when(processRepository.findOne(any(Specification.class))).thenReturn(Optional.of(process));
-        var processService = new ProcessService(processRepository, mock(PermissionService.class));
+        var processService = mock(ProcessService.class);
+        when(processService.retrieveBySlugOrHistory(PROCESS_SLUG)).thenReturn(Optional.of(process));
 
         var processNodeRepository = mock(ProcessNodeRepository.class);
         when(processNodeRepository.findAll(any(Specification.class))).thenReturn(List.of(node));

--- a/src/test/java/de/aivot/GoverBackend/plugins/form/v1/nodes/FormTriggerControllerV1SubmitTest.java
+++ b/src/test/java/de/aivot/GoverBackend/plugins/form/v1/nodes/FormTriggerControllerV1SubmitTest.java
@@ -53,7 +53,7 @@ class FormTriggerControllerV1SubmitTest {
 
         var result = fixture.controller().submit(
                 null,
-                fixture.processAccessKey(),
+                fixture.processSlug(),
                 fixture.formSlug(),
                 null,
                 "identity-session-id",
@@ -97,7 +97,7 @@ class FormTriggerControllerV1SubmitTest {
 
         assertThrows(ResponseException.class, () -> fixture.controller().submit(
                 null,
-                fixture.processAccessKey(),
+                fixture.processSlug(),
                 fixture.formSlug(),
                 null,
                 "identity-session-id",
@@ -119,6 +119,7 @@ class FormTriggerControllerV1SubmitTest {
             UUID startedProcessAccessKey
     ) throws ResponseException {
         var processAccessKey = UUID.randomUUID();
+        var processSlug = "example-process";
         var formSlug = "example-form";
 
         var process = new ProcessEntity()
@@ -126,6 +127,7 @@ class FormTriggerControllerV1SubmitTest {
                 .setInternalTitle("Process")
                 .setDepartmentId(10)
                 .setAccessKey(processAccessKey)
+                .setSlug(processSlug)
                 .setVersionCount(1)
                 .setPublishedVersion(1);
 
@@ -145,7 +147,7 @@ class FormTriggerControllerV1SubmitTest {
         when(userService.fromJWT(isNull())).thenReturn(Optional.empty());
 
         var processService = mock(ProcessService.class);
-        when(processService.retrieveByAccessKey(processAccessKey)).thenReturn(Optional.of(process));
+        when(processService.retrieveBySlugOrHistory(processSlug)).thenReturn(Optional.of(process));
 
         var processVersionService = mock(ProcessVersionService.class);
         when(processVersionService.retrieve(any(de.aivot.GoverBackend.process.filters.ProcessVersionFilter.class)))
@@ -251,7 +253,7 @@ class FormTriggerControllerV1SubmitTest {
 
         return new SubmitFixture(
                 controller,
-                processAccessKey,
+                processSlug,
                 formSlug,
                 node.getId(),
                 identityService,
@@ -278,7 +280,7 @@ class FormTriggerControllerV1SubmitTest {
 
     private record SubmitFixture(
             FormTriggerControllerV1 controller,
-            UUID processAccessKey,
+            String processSlug,
             String formSlug,
             Integer processNodeId,
             IdentityService identityService,

--- a/src/test/java/de/aivot/GoverBackend/plugins/form/v1/nodes/FormTriggerControllerV1Test.java
+++ b/src/test/java/de/aivot/GoverBackend/plugins/form/v1/nodes/FormTriggerControllerV1Test.java
@@ -27,9 +27,11 @@ import de.aivot.GoverBackend.submission.services.ElementDataTransformService;
 import de.aivot.GoverBackend.system.services.SystemService;
 import de.aivot.GoverBackend.theme.entities.ThemeEntity;
 import de.aivot.GoverBackend.theme.services.ThemeService;
+import de.aivot.GoverBackend.user.entities.UserEntity;
 import de.aivot.GoverBackend.user.services.UserService;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.oauth2.jwt.Jwt;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -46,7 +48,7 @@ class FormTriggerControllerV1Test {
 
         when(fixture.themeService().retrieve(formTheme.getId())).thenReturn(Optional.of(formTheme));
 
-        var result = fixture.controller().getTheme(null, fixture.processAccessKey(), fixture.formSlug(), null, null);
+        var result = fixture.controller().getTheme(null, fixture.processSlug(), fixture.formSlug(), null, null);
 
         assertEquals(formTheme.getId(), result.id());
         assertEquals(formTheme.getName(), result.name());
@@ -68,8 +70,8 @@ class FormTriggerControllerV1Test {
         when(fixture.themeService().retrieve(formTheme.getId())).thenReturn(Optional.of(formTheme));
 
         var result = fixture.controller().getTheme(
-                null,
-                fixture.processAccessKey(),
+                mock(Jwt.class),
+                fixture.processSlug(),
                 fixture.formSlug(),
                 testClaimAccessKey,
                 requestedProcessVersion
@@ -101,7 +103,7 @@ class FormTriggerControllerV1Test {
         when(fixture.themeService().retrieve(responsibleTheme.getId())).thenReturn(Optional.of(responsibleTheme));
 
         var response = new MockHttpServletResponse();
-        fixture.controller().getLogo(null, fixture.processAccessKey(), fixture.formSlug(), testClaimAccessKey, null, response);
+        fixture.controller().getLogo(null, fixture.processSlug(), fixture.formSlug(), testClaimAccessKey, null, response);
 
         assertEquals("https://assets.example/" + responsibleTheme.getLogoKey(), response.getRedirectedUrl());
         verify(fixture.processTestClaimService()).retrieveByAccessKey(fixture.process().getId(), testClaimAccessKey);
@@ -115,7 +117,7 @@ class FormTriggerControllerV1Test {
         when(fixture.themeService().retrieve(formTheme.getId())).thenReturn(Optional.of(formTheme));
 
         var response = new MockHttpServletResponse();
-        fixture.controller().getLogo(null, fixture.processAccessKey(), fixture.formSlug(), null, null, response);
+        fixture.controller().getLogo(null, fixture.processSlug(), fixture.formSlug(), null, null, response);
 
         assertEquals("https://gover.example/assets/default-logo.png", response.getRedirectedUrl());
     }
@@ -135,7 +137,7 @@ class FormTriggerControllerV1Test {
         when(fixture.themeService().retrieve(managingTheme.getId())).thenReturn(Optional.of(managingTheme));
 
         var response = new MockHttpServletResponse();
-        fixture.controller().getFavicon(null, fixture.processAccessKey(), fixture.formSlug(), null, null, response);
+        fixture.controller().getFavicon(null, fixture.processSlug(), fixture.formSlug(), null, null, response);
 
         assertEquals("https://assets.example/" + managingTheme.getFaviconKey(), response.getRedirectedUrl());
     }
@@ -145,7 +147,7 @@ class FormTriggerControllerV1Test {
         var fixture = createFixture(baseFormLayout());
 
         var response = new MockHttpServletResponse();
-        fixture.controller().getFavicon(null, fixture.processAccessKey(), fixture.formSlug(), null, null, response);
+        fixture.controller().getFavicon(null, fixture.processSlug(), fixture.formSlug(), null, null, response);
 
         assertEquals("https://gover.example/assets/default-favicon.ico", response.getRedirectedUrl());
     }
@@ -163,6 +165,7 @@ class FormTriggerControllerV1Test {
                                       String testClaimAccessKey,
                                       int resolvedProcessVersion) throws Exception {
         var processAccessKey = UUID.randomUUID();
+        var processSlug = "example-process";
         var formSlug = "example-form";
 
         var goverConfig = mock(GoverConfig.class);
@@ -179,12 +182,14 @@ class FormTriggerControllerV1Test {
 
         var userService = mock(UserService.class);
         when(userService.fromJWT(isNull())).thenReturn(Optional.empty());
+        when(userService.fromJWT(any(Jwt.class))).thenReturn(Optional.of(new UserEntity().setId("staff-user")));
 
         var process = new ProcessEntity()
                 .setId(100)
                 .setInternalTitle("Process")
                 .setDepartmentId(10)
                 .setAccessKey(processAccessKey)
+                .setSlug(processSlug)
                 .setVersionCount(1)
                 .setPublishedVersion(1);
 
@@ -201,7 +206,7 @@ class FormTriggerControllerV1Test {
                 .setProcessNodeDefinitionVersion(1);
 
         var processService = mock(ProcessService.class);
-        when(processService.retrieveByAccessKey(processAccessKey)).thenReturn(Optional.of(process));
+        when(processService.retrieveBySlugOrHistory(processSlug)).thenReturn(Optional.of(process));
 
         var processTestClaimService = mock(ProcessTestClaimService.class);
         if (testClaimAccessKey != null) {
@@ -227,7 +232,7 @@ class FormTriggerControllerV1Test {
         triggerConfig.formSlug = formSlug;
         triggerConfig.formLayout = formLayout;
 
-        when(processNodeService.deriveConfiguration(eq(node), eq(provider), isNull(), eq(true)))
+        when(processNodeService.deriveConfiguration(eq(node), eq(provider), nullable(UserEntity.class), eq(true)))
                 .thenReturn(new ProcessNodeService.ProcessConfigurationDetails<>(
                         triggerConfig,
                         new DerivedRuntimeElementData()
@@ -270,7 +275,7 @@ class FormTriggerControllerV1Test {
 
         return new TestFixture(
                 controller,
-                processAccessKey,
+                processSlug,
                 formSlug,
                 process,
                 processTestClaimService,
@@ -306,7 +311,7 @@ class FormTriggerControllerV1Test {
 
     private record TestFixture(
             FormTriggerControllerV1 controller,
-            UUID processAccessKey,
+            String processSlug,
             String formSlug,
             ProcessEntity process,
             ProcessTestClaimService processTestClaimService,

--- a/src/test/java/de/aivot/GoverBackend/plugins/form/v1/nodes/FormTriggerNodeV1Test.java
+++ b/src/test/java/de/aivot/GoverBackend/plugins/form/v1/nodes/FormTriggerNodeV1Test.java
@@ -2,9 +2,9 @@ package de.aivot.GoverBackend.plugins.form.v1.nodes;
 
 import de.aivot.GoverBackend.elements.models.AuthoredElementValues;
 import de.aivot.GoverBackend.elements.models.elements.layout.FormLayoutElement;
-import de.aivot.GoverBackend.models.config.GoverConfig;
 import de.aivot.GoverBackend.process.entities.ProcessNodeEntity;
 import de.aivot.GoverBackend.process.repositories.ProcessNodeRepository;
+import de.aivot.GoverBackend.process.services.PublicUrlService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.jpa.domain.Specification;
@@ -30,7 +30,7 @@ class FormTriggerNodeV1Test {
     @BeforeEach
     void setUp() {
         processNodeRepository = mock(ProcessNodeRepository.class);
-        node = new FormTriggerNodeV1(mock(GoverConfig.class), processNodeRepository);
+        node = new FormTriggerNodeV1(mock(PublicUrlService.class), processNodeRepository);
     }
 
     @Test
@@ -78,7 +78,7 @@ class FormTriggerNodeV1Test {
 
         assertNotNull(errors);
         assertEquals(
-                "Die Formular-URL wird in dieser Prozessversion bereits von einem anderen Formulareingang verwendet.",
+                "Das URL-Segment des Formulars wird in dieser Prozessversion bereits von einem anderen Formulareingang verwendet.",
                 errors.get(FormTriggerConfigV1.FORM_SLUG)
         );
     }

--- a/src/test/java/de/aivot/GoverBackend/plugins/form/v1/nodes/FormTriggerUtilsControllerV1Test.java
+++ b/src/test/java/de/aivot/GoverBackend/plugins/form/v1/nodes/FormTriggerUtilsControllerV1Test.java
@@ -5,7 +5,6 @@ import de.aivot.GoverBackend.department.services.VDepartmentShadowedService;
 import de.aivot.GoverBackend.elements.models.DerivedRuntimeElementData;
 import de.aivot.GoverBackend.elements.models.elements.layout.FormLayoutElement;
 import de.aivot.GoverBackend.lib.exceptions.ResponseException;
-import de.aivot.GoverBackend.models.config.GoverConfig;
 import de.aivot.GoverBackend.pdf.models.PrintableFormPdfData;
 import de.aivot.GoverBackend.permissions.services.PermissionService;
 import de.aivot.GoverBackend.process.entities.ProcessEntity;
@@ -14,6 +13,7 @@ import de.aivot.GoverBackend.process.permissions.ProcessPermissionProvider;
 import de.aivot.GoverBackend.process.services.ProcessNodeDefinitionService;
 import de.aivot.GoverBackend.process.services.ProcessNodeService;
 import de.aivot.GoverBackend.process.services.ProcessService;
+import de.aivot.GoverBackend.process.services.PublicUrlService;
 import de.aivot.GoverBackend.services.PdfService;
 import de.aivot.GoverBackend.system.services.SystemService;
 import de.aivot.GoverBackend.theme.entities.ThemeEntity;
@@ -66,8 +66,8 @@ class FormTriggerUtilsControllerV1Test {
         var printableFormCaptor = ArgumentCaptor.forClass(PrintableFormPdfData.class);
         verify(fixture.pdfService()).generatePrintableForm(printableFormCaptor.capture(), eq(formTheme), eq(responsibleDepartment));
         var printableForm = printableFormCaptor.getValue();
-        assertEquals("/forms/v1/%s/%s/?version=%d".formatted(
-                fixture.process().getAccessKey(),
+        assertEquals("/form/%s/%s/?version=%d".formatted(
+                fixture.process().getSlug(),
                 fixture.formSlug(),
                 fixture.node().getProcessVersion()
         ), printableForm.getSlug());
@@ -138,11 +138,12 @@ class FormTriggerUtilsControllerV1Test {
 
     private TestFixture createFixture(FormLayoutElement formLayout) throws Exception {
         var processAccessKey = UUID.randomUUID();
+        var processSlug = "example-process";
         var formSlug = "example-form";
 
-        var goverConfig = mock(GoverConfig.class);
-        when(goverConfig.createUrlWithTrailingSlash("/forms/v1/", processAccessKey, formSlug))
-                .thenReturn("https://gover.example/forms/v1/%s/%s/".formatted(processAccessKey, formSlug));
+        var publicUrlService = mock(PublicUrlService.class);
+        when(publicUrlService.createPublicFormUrl(any(ProcessEntity.class), eq(formSlug)))
+                .thenReturn("https://gover.example/form/%s/%s/".formatted(processSlug, formSlug));
 
         var user = new UserEntity()
                 .setId("user-1");
@@ -155,6 +156,7 @@ class FormTriggerUtilsControllerV1Test {
                 .setId(100)
                 .setDepartmentId(400)
                 .setAccessKey(processAccessKey)
+                .setSlug(processSlug)
                 .setInternalTitle("Process")
                 .setVersionCount(1)
                 .setPublishedVersion(1);
@@ -200,7 +202,7 @@ class FormTriggerUtilsControllerV1Test {
                 .thenReturn(new byte[]{0});
 
         var controller = new FormTriggerUtilsControllerV1(
-                goverConfig,
+                publicUrlService,
                 userService,
                 permissionService,
                 processService,

--- a/src/test/java/de/aivot/GoverBackend/process/controllers/StaffProcessInstanceTaskViewControllerTest.java
+++ b/src/test/java/de/aivot/GoverBackend/process/controllers/StaffProcessInstanceTaskViewControllerTest.java
@@ -390,7 +390,7 @@ class StaffProcessInstanceTaskViewControllerTest {
         private final ProcessEntity process;
 
         private TestProcessService(ProcessEntity process) {
-            super(null, null);
+            super(null, null, null);
             this.process = process;
         }
 

--- a/src/test/java/de/aivot/GoverBackend/process/services/CaseNumberGeneratorServiceTest.java
+++ b/src/test/java/de/aivot/GoverBackend/process/services/CaseNumberGeneratorServiceTest.java
@@ -74,7 +74,7 @@ class CaseNumberGeneratorServiceTest {
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus());
         assertEquals(
-                "Die Aktenzeichenvorlage enthält einen unbekannten Platzhalter an Position 4. Unterstützt werden %YYY, %Y, %M, %D, %h, %m und %I(n).",
+                "Die Vorgangsschlüssel-Formatvorlage enthält einen unbekannten Platzhalter an Position 4. Unterstützt werden %YYY, %Y, %M, %D, %h, %m und %I(n).",
                 exception.getTitle()
         );
     }
@@ -90,7 +90,7 @@ class CaseNumberGeneratorServiceTest {
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus());
         assertEquals(
-                "Die Aktenzeichenvorlage muss genau einen Inkrement-Platzhalter im Format %I(n) enthalten.",
+                "Die Vorgangsschlüssel-Formatvorlage muss genau einen Inkrement-Platzhalter im Format %I(n) enthalten.",
                 exception.getTitle()
         );
     }
@@ -106,7 +106,7 @@ class CaseNumberGeneratorServiceTest {
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus());
         assertEquals(
-                "Die Inkrement-Breite in der Aktenzeichenvorlage muss zwischen 4 und 12 Stellen liegen.",
+                "Die Inkrement-Breite in der Vorgangsschlüssel-Formatvorlage muss zwischen 4 und 12 Stellen liegen.",
                 exception.getTitle()
         );
     }
@@ -122,7 +122,7 @@ class CaseNumberGeneratorServiceTest {
 
         assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus());
         assertEquals(
-                "Das erzeugte Aktenzeichen würde das Limit von 36 Zeichen überschreiten.",
+                "Der erzeugte Vorgangsschlüssel würde das Limit von 36 Zeichen überschreiten.",
                 exception.getTitle()
         );
     }

--- a/src/test/java/de/aivot/GoverBackend/process/services/ProcessServiceTest.java
+++ b/src/test/java/de/aivot/GoverBackend/process/services/ProcessServiceTest.java
@@ -1,9 +1,12 @@
 package de.aivot.GoverBackend.process.services;
 
 import de.aivot.GoverBackend.permissions.services.PermissionService;
+import de.aivot.GoverBackend.lib.exceptions.ResponseException;
 import de.aivot.GoverBackend.process.entities.ProcessEntity;
+import de.aivot.GoverBackend.process.entities.ProcessSlugHistoryEntity;
 import de.aivot.GoverBackend.process.permissions.ProcessPermissionProvider;
 import de.aivot.GoverBackend.process.repositories.ProcessRepository;
+import de.aivot.GoverBackend.process.repositories.ProcessSlugHistoryRepository;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Path;
@@ -17,9 +20,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -34,10 +39,129 @@ class ProcessServiceTest {
     private static final String READ_PERMISSION = ProcessPermissionProvider.PROCESS_DEFINITION_READ;
 
     @Test
+    void createShouldNormalizeExplicitSlug() throws Exception {
+        var repository = mock(ProcessRepository.class);
+        var processSlugHistoryRepository = mock(ProcessSlugHistoryRepository.class);
+        var permissionService = mock(PermissionService.class);
+        var service = new ProcessService(repository, processSlugHistoryRepository, permissionService);
+        var process = new ProcessEntity()
+                .setInternalTitle("Hundesteuer Antrag")
+                .setDepartmentId(10)
+                .setSlug("Hundesteuer-Antrag")
+                .setVersionCount(0);
+
+        when(repository.save(any(ProcessEntity.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        var result = service.create(process);
+
+        assertEquals("hundesteuer-antrag", result.getSlug());
+        assertEquals(10, result.getDepartmentId());
+        verify(repository).save(process);
+    }
+
+    @Test
+    void createShouldRejectMissingSlug() {
+        var repository = mock(ProcessRepository.class);
+        var processSlugHistoryRepository = mock(ProcessSlugHistoryRepository.class);
+        var permissionService = mock(PermissionService.class);
+        var service = new ProcessService(repository, processSlugHistoryRepository, permissionService);
+        var process = new ProcessEntity()
+                .setInternalTitle("Hundesteuer Antrag")
+                .setDepartmentId(10)
+                .setSlug("")
+                .setVersionCount(0);
+
+        assertThrows(ResponseException.class, () -> service.create(process));
+        verify(repository, never()).save(any(ProcessEntity.class));
+    }
+
+    @Test
+    void retrieveBySlugOrHistoryShouldResolveHistoricalSlug() throws Exception {
+        var repository = mock(ProcessRepository.class);
+        var processSlugHistoryRepository = mock(ProcessSlugHistoryRepository.class);
+        var permissionService = mock(PermissionService.class);
+        var service = new ProcessService(repository, processSlugHistoryRepository, permissionService);
+        var process = new ProcessEntity()
+                .setId(42)
+                .setInternalTitle("Hundesteuer Antrag")
+                .setDepartmentId(10)
+                .setSlug("hundesteuer")
+                .setVersionCount(1);
+
+        when(repository.findBySlug("alter-slug"))
+                .thenReturn(Optional.empty());
+        when(processSlugHistoryRepository.findBySlug("alter-slug"))
+                .thenReturn(Optional.of(new ProcessSlugHistoryEntity("alter-slug", 42)));
+        when(repository.findById(42))
+                .thenReturn(Optional.of(process));
+
+        var result = service.retrieveBySlugOrHistory("ALTER-SLUG");
+
+        assertTrue(result.isPresent());
+        assertSame(process, result.get());
+    }
+
+    @Test
+    void listSlugHistoryShouldReturnEntriesForExistingProcess() throws Exception {
+        var repository = mock(ProcessRepository.class);
+        var processSlugHistoryRepository = mock(ProcessSlugHistoryRepository.class);
+        var permissionService = mock(PermissionService.class);
+        var service = new ProcessService(repository, processSlugHistoryRepository, permissionService);
+        var history = List.of(
+                new ProcessSlugHistoryEntity("alter-slug", 42),
+                new ProcessSlugHistoryEntity("noch-aelterer-slug", 42)
+        );
+
+        when(repository.existsById(42))
+                .thenReturn(true);
+        when(processSlugHistoryRepository.findAllByProcessIdOrderByCreatedDesc(42))
+                .thenReturn(history);
+
+        var result = service.listSlugHistory(42);
+
+        assertSame(history, result);
+        verify(processSlugHistoryRepository).findAllByProcessIdOrderByCreatedDesc(42);
+    }
+
+    @Test
+    void clearSlugHistoryShouldDeleteEntriesForExistingProcess() throws Exception {
+        var repository = mock(ProcessRepository.class);
+        var processSlugHistoryRepository = mock(ProcessSlugHistoryRepository.class);
+        var permissionService = mock(PermissionService.class);
+        var service = new ProcessService(repository, processSlugHistoryRepository, permissionService);
+
+        when(repository.existsById(42))
+                .thenReturn(true);
+
+        service.clearSlugHistory(42);
+
+        verify(processSlugHistoryRepository).deleteAllByProcessId(42);
+    }
+
+    @Test
+    void isSlugAvailableShouldAllowCurrentProcessSlug() throws Exception {
+        var repository = mock(ProcessRepository.class);
+        var processSlugHistoryRepository = mock(ProcessSlugHistoryRepository.class);
+        var permissionService = mock(PermissionService.class);
+        var service = new ProcessService(repository, processSlugHistoryRepository, permissionService);
+
+        when(repository.existsBySlugAndIdIsNot("hundesteuer", 42))
+                .thenReturn(false);
+        when(processSlugHistoryRepository.existsBySlugAndProcessIdIsNot("hundesteuer", 42))
+                .thenReturn(false);
+
+        var result = service.isSlugAvailable("Hundesteuer", 42);
+
+        assertTrue(result);
+    }
+
+    @Test
     void listAllByAccessibleForUserShouldReturnUnscopedResultForSystemReadPermission() throws Exception {
         var repository = mock(ProcessRepository.class);
+        var processSlugHistoryRepository = mock(ProcessSlugHistoryRepository.class);
         var permissionService = mock(PermissionService.class);
-        var service = new ProcessService(repository, permissionService);
+        var service = new ProcessService(repository, processSlugHistoryRepository, permissionService);
         var pageable = PageRequest.of(0, 10);
         Specification<ProcessEntity> specification = (root, query, criteriaBuilder) -> criteriaBuilder.conjunction();
         var page = Page.<ProcessEntity>empty(pageable);
@@ -58,8 +182,9 @@ class ProcessServiceTest {
     @Test
     void listAllByAccessibleForUserShouldReturnEmptyPageWhenUserHasNoScopedAccess() throws Exception {
         var repository = mock(ProcessRepository.class);
+        var processSlugHistoryRepository = mock(ProcessSlugHistoryRepository.class);
         var permissionService = mock(PermissionService.class);
-        var service = new ProcessService(repository, permissionService);
+        var service = new ProcessService(repository, processSlugHistoryRepository, permissionService);
         var pageable = PageRequest.of(0, 10);
 
         when(permissionService.hasSystemPermission(USER_ID, READ_PERMISSION))
@@ -79,8 +204,9 @@ class ProcessServiceTest {
     @Test
     void listAllByAccessibleForUserShouldScopeByDepartmentsAndExplicitProcessAccess() throws Exception {
         var repository = mock(ProcessRepository.class);
+        var processSlugHistoryRepository = mock(ProcessSlugHistoryRepository.class);
         var permissionService = mock(PermissionService.class);
-        var service = new ProcessService(repository, permissionService);
+        var service = new ProcessService(repository, processSlugHistoryRepository, permissionService);
         var pageable = PageRequest.of(0, 10);
         var page = Page.<ProcessEntity>empty(pageable);
 


### PR DESCRIPTION
This PR introduces process-level URL namespaces and updates public form/webhook URLs to use them.

**Changes**
- Add process slug persistence, validation, availability checks, and slug history.
- Route public forms via `/form/{processSlug}/{formSlug}`.
- Route public form APIs via `/api/public/form/{processSlug}/{formSlug}/...`.
- Route webhooks via `/api/public/webhook/{processSlug}/{webhookSlug}/...`.
- Add process settings for URL namespace, slug history, public label, and case number format.
- Add process transfer controls for changing the managing department.
- Remove legacy form links from the form root editor.