### PR TITLE
fix: change storage health report

### DIFF
--- a/app/src/models/dtos/health-data.ts
+++ b/app/src/models/dtos/health-data.ts
@@ -42,11 +42,13 @@ export interface HealthDataComponents {
         version: string;
     }>;
     storage: BaseComponent<{
+        error?: string;
         providers: Array<{
             name: string;
             definitionKey: string;
             definitionVersion: string;
             definitionName?: string;
+            isDefaultAttachmentStorage: boolean;
             error?: string;
             hint?: string;
         }>

--- a/app/src/models/dtos/health-data.ts
+++ b/app/src/models/dtos/health-data.ts
@@ -42,7 +42,7 @@ export interface HealthDataComponents {
         version: string;
     }>;
     storage: BaseComponent<{
-        hint?: string;
-        error?: string;
+        hints?: string[];
+        errors?: string[];
     }>;
 }

--- a/app/src/models/dtos/health-data.ts
+++ b/app/src/models/dtos/health-data.ts
@@ -42,7 +42,13 @@ export interface HealthDataComponents {
         version: string;
     }>;
     storage: BaseComponent<{
-        hints?: string[];
-        errors?: string[];
+        providers: Array<{
+            name: string;
+            definitionKey: string;
+            definitionVersion: string;
+            definitionName?: string;
+            error?: string;
+            hint?: string;
+        }>
     }>;
 }

--- a/backend/src/main/java/de/aivot/gover/backend/storage/StorageHealthIndicator.java
+++ b/backend/src/main/java/de/aivot/gover/backend/storage/StorageHealthIndicator.java
@@ -1,17 +1,23 @@
 package de.aivot.gover.backend.storage;
 
+import de.aivot.gover.backend.config.services.SystemConfigService;
 import de.aivot.gover.backend.lib.exceptions.ResponseException;
+import de.aivot.gover.backend.process.configs.DefaultStorageProcessAttachmentsSystemConfigDefinition;
 import de.aivot.gover.backend.storage.entities.StorageProviderEntity;
 import de.aivot.gover.backend.storage.exceptions.StorageException;
 import de.aivot.gover.backend.storage.models.StorageProviderDefinition;
 import de.aivot.gover.backend.storage.repositories.StorageProviderRepository;
 import de.aivot.gover.backend.storage.services.StorageProviderConfigurationService;
 import de.aivot.gover.backend.storage.services.StorageProviderDefinitionService;
+import de.aivot.gover.backend.utils.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Component("storage")
 @ConditionalOnEnabledHealthIndicator("storage")
@@ -20,28 +26,51 @@ public class StorageHealthIndicator implements HealthIndicator {
     private final StorageProviderRepository storageProviderRepository;
     private final StorageProviderDefinitionService storageProviderDefinitionService;
     private final StorageProviderConfigurationService storageProviderConfigurationService;
+    private final SystemConfigService systemConfigService;
 
     @Autowired
     public StorageHealthIndicator(StorageProviderRepository storageProviderRepository,
                                   StorageProviderDefinitionService storageProviderDefinitionService,
-                                  StorageProviderConfigurationService storageProviderConfigurationService) {
+                                  StorageProviderConfigurationService storageProviderConfigurationService,
+                                  SystemConfigService systemConfigService) {
         this.storageProviderRepository = storageProviderRepository;
         this.storageProviderDefinitionService = storageProviderDefinitionService;
         this.storageProviderConfigurationService = storageProviderConfigurationService;
+        this.systemConfigService = systemConfigService;
     }
 
     @Override
     public Health health() {
+        // Fetch the default attachment storage id to check if the default attachment storage is down, which would be critical.
+        String defaultAttachmentStorage;
+        try {
+            var val = systemConfigService
+                    .getValue(DefaultStorageProcessAttachmentsSystemConfigDefinition.KEY);
+
+            if (val != null) {
+                defaultAttachmentStorage = val.toString();
+            } else {
+                defaultAttachmentStorage = null;
+            }
+        } catch (ResponseException e) {
+            defaultAttachmentStorage = null;
+        }
+
         var providers = storageProviderRepository
                 .findAll();
 
+        // If no storage providers are configured they are per definition up.
         if (providers.isEmpty()) {
             return Health
-                    .unknown()
+                    .up()
                     .withDetail("hint", "Es sind keine Speicheranbieter konfiguriert.")
                     .build();
         }
 
+        List<String> errors = new ArrayList<>();
+        List<String> hints = new ArrayList<>();
+
+        // Check for all storage providers if they are reachable.
         for (var provider : providers) {
             var def = storageProviderDefinitionService
                     .retrieveProviderDefinition(
@@ -50,26 +79,61 @@ public class StorageHealthIndicator implements HealthIndicator {
                     )
                     .orElse(null);
 
+            // If a storage provider definition is missing, the health check should be down, because this is a misconfiguration and the sysadmin needs to add the corresponding plugin again.
             if (def == null) {
-                return Health
-                        .down()
-                        .withDetail("hint", "Der Speicheranbieter '" + provider.getName() + "' referenziert eine nicht vorhandene Anbieterdefinition.")
-                        .build();
+                var msg = String.format(
+                        "Der Der Speicheranbieter %s referenziert eine nicht vorhandene Anbieterdefinition %s Version %d. Bitte stellen Sie sicher, dass das entsprechende Plugin wieder installiert wird.",
+                        StringUtils.quote(provider.getName()),
+                        StringUtils.quote(provider.getStorageProviderDefinitionKey()),
+                        provider.getStorageProviderDefinitionVersion()
+                );
+
+                errors.add(msg);
             }
 
+            // Check the connection to each storage provider.
             try {
                 testConnection(provider, def);
             } catch (Exception e) {
-                return Health
-                        .down()
-                        .withDetail("error", "Verbindungstest zum Speicheranbieter '" + provider.getName() + "' ist fehlgeschlagen. Fehlermeldung: " + e.getMessage())
-                        .build();
+                var msg = String.format(
+                        "Verbindungstest zum Speicheranbieter %s ist fehlgeschlagen. Fehlermeldung: %s",
+                        StringUtils.quote(provider.getName()),
+                        e.getMessage()
+                );
+
+                // Check if the currently checked storage provider is the default attachment storage.
+                // If so, the health check should fail because this is a critical component and the system cannot function properly if the process attachments cannot be stored.
+                // For all non default attachment storages just drop a hint
+                if (defaultAttachmentStorage != null && defaultAttachmentStorage.equals(provider.getId().toString())) {
+                    msg += " Dieser Speicheranbieter ist als Standard-Speicheranbieter für Anhänge von Vorgängen konfiguriert. Bitte stellen Sie sicher, dass der Speicheranbieter erreichbar ist.";
+
+                    errors.add(msg);
+                } else {
+                    hints.add(msg);
+                }
             }
         }
 
-        return Health
-                .up()
-                .build();
+        // Create the builder for the health check result based on the errors and hints collected during the checks.
+        // If errors exist, the component is down. If hints exist the component is afflicted. If no errors and no hints exist, the component is simply up.
+        Health.Builder builder;
+        if (!errors.isEmpty()) {
+            builder = Health.down();
+        } else if (!hints.isEmpty()) {
+            builder = Health.unknown();
+        } else {
+            builder = Health.up();
+        }
+
+        if (!errors.isEmpty()) {
+            builder.withDetail("errors", errors);
+        }
+
+        if (!hints.isEmpty()) {
+            builder.withDetail("hints", hints);
+        }
+
+        return builder.build();
     }
 
     private <T> void testConnection(StorageProviderEntity provider, StorageProviderDefinition<T> definition) throws StorageException {

--- a/backend/src/main/java/de/aivot/gover/backend/storage/StorageHealthIndicator.java
+++ b/backend/src/main/java/de/aivot/gover/backend/storage/StorageHealthIndicator.java
@@ -24,6 +24,7 @@ import java.util.Map;
 @Component("storage")
 @ConditionalOnEnabledHealthIndicator("storage")
 public class StorageHealthIndicator implements HealthIndicator {
+    private static final String PROVIDERS_DETAILS_KEY = "providers";
 
     private final StorageProviderRepository storageProviderRepository;
     private final StorageProviderDefinitionService storageProviderDefinitionService;
@@ -65,7 +66,7 @@ public class StorageHealthIndicator implements HealthIndicator {
         if (providers.isEmpty()) {
             return Health
                     .up()
-                    .withDetail("hint", "Es sind keine Speicheranbieter konfiguriert.")
+                    .withDetail(PROVIDERS_DETAILS_KEY, new ArrayList<>())
                     .build();
         }
 
@@ -91,7 +92,7 @@ public class StorageHealthIndicator implements HealthIndicator {
             // If a storage provider definition is missing, the health check should be down, because this is a misconfiguration and the sysadmin needs to add the corresponding plugin again.
             if (def == null) {
                 var msg = String.format(
-                        "Der Der Speicheranbieter %s referenziert eine nicht vorhandene Anbieterdefinition %s Version %d. Bitte stellen Sie sicher, dass das entsprechende Plugin wieder installiert wird.",
+                        "Der Speicheranbieter %s referenziert eine nicht vorhandene Anbieterdefinition %s Version %d. Bitte stellen Sie sicher, dass das entsprechende Plugin wieder installiert wird.",
                         StringUtils.quote(provider.getName()),
                         StringUtils.quote(provider.getStorageProviderDefinitionKey()),
                         provider.getStorageProviderDefinitionVersion()
@@ -101,7 +102,7 @@ public class StorageHealthIndicator implements HealthIndicator {
                 providerDetail.put("error", msg);
                 hasErrors = true;
                 providerDetails.add(providerDetail);
-                break;
+                continue;
             }
 
             providerDetail.put("definitionName", def.getName());
@@ -145,7 +146,7 @@ public class StorageHealthIndicator implements HealthIndicator {
         }
 
         return builder
-                .withDetail("providers", providerDetails)
+                .withDetail(PROVIDERS_DETAILS_KEY, providerDetails)
                 .build();
     }
 

--- a/backend/src/main/java/de/aivot/gover/backend/storage/StorageHealthIndicator.java
+++ b/backend/src/main/java/de/aivot/gover/backend/storage/StorageHealthIndicator.java
@@ -62,26 +62,21 @@ public class StorageHealthIndicator implements HealthIndicator {
         var providers = storageProviderRepository
                 .findAll();
 
-        // If no storage providers are configured they are per definition up.
-        if (providers.isEmpty()) {
-            return Health
-                    .up()
-                    .withDetail(PROVIDERS_DETAILS_KEY, new ArrayList<>())
-                    .build();
-        }
-
         boolean hasErrors = defaultAttachmentStorage == null;
         boolean hasHints = false;
+        boolean defaultAttachmentsProviderIsPresent = false;
 
         List<Map<String, Object>> providerDetails = new ArrayList<>();
 
         // Check for all storage providers if they are reachable.
         for (var provider : providers) {
+            var isDefaultAttachmentStorage = defaultAttachmentStorage != null && defaultAttachmentStorage.equals(provider.getId().toString());
+
             var providerDetail = new HashMap<String, Object>();
             providerDetail.put("name", provider.getName());
             providerDetail.put("definitionKey", provider.getStorageProviderDefinitionKey());
             providerDetail.put("definitionVersion", String.valueOf(provider.getStorageProviderDefinitionVersion()));
-            providerDetail.put("isDefaultAttachmentStorage", defaultAttachmentStorage != null && defaultAttachmentStorage.equals(provider.getId().toString()));
+            providerDetail.put("isDefaultAttachmentStorage", isDefaultAttachmentStorage);
 
             var def = storageProviderDefinitionService
                     .retrieveProviderDefinition(
@@ -133,6 +128,10 @@ public class StorageHealthIndicator implements HealthIndicator {
             }
 
             providerDetails.add(providerDetail);
+
+            if (isDefaultAttachmentStorage) {
+                defaultAttachmentsProviderIsPresent = true;
+            }
         }
 
         // Create the builder for the health check result based on the errors and hints collected during the checks.
@@ -148,6 +147,11 @@ public class StorageHealthIndicator implements HealthIndicator {
 
         if (defaultAttachmentStorage == null) {
             builder.withDetail("error", "Der Standard-Speicheranbieter für Anhänge von Vorgängen ist nicht konfiguriert. Bitte konfigurieren Sie einen Speicheranbieter als Standard-Speicheranbieter für Anhänge von Vorgängen.");
+        } else if (!defaultAttachmentsProviderIsPresent) {
+            builder.withDetail("error", String.format(
+                    "Der Standard-Speicheranbieter für Anhänge von Vorgängen (ID: %s) ist nicht vorhanden. Bitte stellen Sie sicher, dass der Speicheranbieter erreichbar ist.",
+                    defaultAttachmentStorage
+            ));
         }
 
         return builder

--- a/backend/src/main/java/de/aivot/gover/backend/storage/StorageHealthIndicator.java
+++ b/backend/src/main/java/de/aivot/gover/backend/storage/StorageHealthIndicator.java
@@ -17,7 +17,9 @@ import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Component("storage")
 @ConditionalOnEnabledHealthIndicator("storage")
@@ -67,11 +69,18 @@ public class StorageHealthIndicator implements HealthIndicator {
                     .build();
         }
 
-        List<String> errors = new ArrayList<>();
-        List<String> hints = new ArrayList<>();
+        boolean hasErrors = false;
+        boolean hasHints = false;
+
+        List<Map<String, String>> providerDetails = new ArrayList<>();
 
         // Check for all storage providers if they are reachable.
         for (var provider : providers) {
+            var providerDetail = new HashMap<String, String>();
+            providerDetail.put("name", provider.getName());
+            providerDetail.put("definitionKey", provider.getStorageProviderDefinitionKey());
+            providerDetail.put("definitionVersion", String.valueOf(provider.getStorageProviderDefinitionVersion()));
+
             var def = storageProviderDefinitionService
                     .retrieveProviderDefinition(
                             provider.getStorageProviderDefinitionKey(),
@@ -88,8 +97,14 @@ public class StorageHealthIndicator implements HealthIndicator {
                         provider.getStorageProviderDefinitionVersion()
                 );
 
-                errors.add(msg);
+
+                providerDetail.put("error", msg);
+                hasErrors = true;
+                providerDetails.add(providerDetail);
+                break;
             }
+
+            providerDetail.put("definitionName", def.getName());
 
             // Check the connection to each storage provider.
             try {
@@ -107,33 +122,31 @@ public class StorageHealthIndicator implements HealthIndicator {
                 if (defaultAttachmentStorage != null && defaultAttachmentStorage.equals(provider.getId().toString())) {
                     msg += " Dieser Speicheranbieter ist als Standard-Speicheranbieter für Anhänge von Vorgängen konfiguriert. Bitte stellen Sie sicher, dass der Speicheranbieter erreichbar ist.";
 
-                    errors.add(msg);
+                    providerDetail.put("error", msg);
+                    hasErrors = true;
                 } else {
-                    hints.add(msg);
+                    providerDetail.put("hint", msg);
+                    hasHints = true;
                 }
             }
+
+            providerDetails.add(providerDetail);
         }
 
         // Create the builder for the health check result based on the errors and hints collected during the checks.
         // If errors exist, the component is down. If hints exist the component is afflicted. If no errors and no hints exist, the component is simply up.
         Health.Builder builder;
-        if (!errors.isEmpty()) {
+        if (hasErrors) {
             builder = Health.down();
-        } else if (!hints.isEmpty()) {
+        } else if (hasHints) {
             builder = Health.unknown();
         } else {
             builder = Health.up();
         }
 
-        if (!errors.isEmpty()) {
-            builder.withDetail("errors", errors);
-        }
-
-        if (!hints.isEmpty()) {
-            builder.withDetail("hints", hints);
-        }
-
-        return builder.build();
+        return builder
+                .withDetail("providers", providerDetails)
+                .build();
     }
 
     private <T> void testConnection(StorageProviderEntity provider, StorageProviderDefinition<T> definition) throws StorageException {

--- a/backend/src/main/java/de/aivot/gover/backend/storage/StorageHealthIndicator.java
+++ b/backend/src/main/java/de/aivot/gover/backend/storage/StorageHealthIndicator.java
@@ -70,17 +70,18 @@ public class StorageHealthIndicator implements HealthIndicator {
                     .build();
         }
 
-        boolean hasErrors = false;
+        boolean hasErrors = defaultAttachmentStorage == null;
         boolean hasHints = false;
 
-        List<Map<String, String>> providerDetails = new ArrayList<>();
+        List<Map<String, Object>> providerDetails = new ArrayList<>();
 
         // Check for all storage providers if they are reachable.
         for (var provider : providers) {
-            var providerDetail = new HashMap<String, String>();
+            var providerDetail = new HashMap<String, Object>();
             providerDetail.put("name", provider.getName());
             providerDetail.put("definitionKey", provider.getStorageProviderDefinitionKey());
             providerDetail.put("definitionVersion", String.valueOf(provider.getStorageProviderDefinitionVersion()));
+            providerDetail.put("isDefaultAttachmentStorage", defaultAttachmentStorage != null && defaultAttachmentStorage.equals(provider.getId().toString()));
 
             var def = storageProviderDefinitionService
                     .retrieveProviderDefinition(
@@ -143,6 +144,10 @@ public class StorageHealthIndicator implements HealthIndicator {
             builder = Health.unknown();
         } else {
             builder = Health.up();
+        }
+
+        if (defaultAttachmentStorage == null) {
+            builder.withDetail("error", "Der Standard-Speicheranbieter für Anhänge von Vorgängen ist nicht konfiguriert. Bitte konfigurieren Sie einen Speicheranbieter als Standard-Speicheranbieter für Anhänge von Vorgängen.");
         }
 
         return builder

--- a/backend/src/main/java/de/aivot/gover/backend/storage/StorageHealthIndicator.java
+++ b/backend/src/main/java/de/aivot/gover/backend/storage/StorageHealthIndicator.java
@@ -62,7 +62,7 @@ public class StorageHealthIndicator implements HealthIndicator {
         var providers = storageProviderRepository
                 .findAll();
 
-        boolean hasErrors = defaultAttachmentStorage == null;
+        boolean hasErrors = false;
         boolean hasHints = false;
         boolean defaultAttachmentsProviderIsPresent = false;
 
@@ -137,7 +137,7 @@ public class StorageHealthIndicator implements HealthIndicator {
         // Create the builder for the health check result based on the errors and hints collected during the checks.
         // If errors exist, the component is down. If hints exist the component is afflicted. If no errors and no hints exist, the component is simply up.
         Health.Builder builder;
-        if (hasErrors) {
+        if (hasErrors || defaultAttachmentStorage == null || !defaultAttachmentsProviderIsPresent) {
             builder = Health.down();
         } else if (hasHints) {
             builder = Health.unknown();

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -136,7 +136,7 @@ management:
   endpoint:
     health:
       access: read_only
-      show-details: when-authorized
+      show-details: when_authorized
 
   health:
     diskspace:


### PR DESCRIPTION
# Description
No matter which storage provider was broken, the health endpoint returned a down state. This prevents the restart of an api if one of the providers goes down, because possible load balancers checking the up state are not forwarding to the staff page so you can fix these configuration issues.

This is not correct and hard to debug. To solve this, the storage health check is updated to only fail if the currently selected attachment storage provider is down or a storage provider definition is missing. Additionally the health check details where improved to include details for all configured providers with their respective general configuration (name, which provider definition key, provider definition version and provider definition name) as well as possible hints and errors.

# Ticket
- OP#164