### PR TITLE
devops: pipeline on pr base change

### DIFF
--- a/.github/workflows/build-alpha.yml
+++ b/.github/workflows/build-alpha.yml
@@ -7,6 +7,7 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+      - edited
     branches:
       - "milestone/*"
       - "patch/*"
@@ -14,7 +15,8 @@ on:
 jobs:
   prepareBuildVars:
     name: Prepare
-    if: github.event.pull_request.draft == false
+    # Run if the pr is not a draft and the trigger it's a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
+    if: github.event.pull_request.draft == false && (github.event.action != 'edited' || github.event.changes.base)
     runs-on: ubuntu-24.04
     outputs:
       build_date: ${{ steps.build_date.outputs.value }}
@@ -41,7 +43,8 @@ jobs:
 
   testBackend:
     name: Test Backend
-    if: github.event.pull_request.draft == false
+    # Run if the pr is not a draft and the trigger it's a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
+    if: github.event.pull_request.draft == false && (github.event.action != 'edited' || github.event.changes.base)
     needs:
       - prepareBuildVars
     uses: ./.github/workflows/test-backend.yml
@@ -52,7 +55,8 @@ jobs:
 
   generateSbom:
     name: SBOM
-    if: github.event.pull_request.draft == false
+    # Run if the pr is not a draft and the trigger it's a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
+    if: github.event.pull_request.draft == false && (github.event.action != 'edited' || github.event.changes.base)
     needs:
       - prepareBuildVars
     uses: ./.github/workflows/generate-sbom.yml
@@ -67,7 +71,8 @@ jobs:
 
   genrateLibrary:
     name: Java Library
-    if: github.event.pull_request.draft == false
+    # Run if the pr is not a draft and the trigger it's a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
+    if: github.event.pull_request.draft == false && (github.event.action != 'edited' || github.event.changes.base)
     needs:
       - prepareBuildVars
       - testBackend
@@ -82,7 +87,8 @@ jobs:
 
   generateImage:
     name: Container Image
-    if: github.event.pull_request.draft == false && needs.prepareBuildVars.outputs.build_version != '0.0.0'
+    # Run if the pr is not a draft and the build version is valid (not 0.0.0) and the trigger it's a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
+    if: github.event.pull_request.draft == false && needs.prepareBuildVars.outputs.build_version != '0.0.0' && (github.event.action != 'edited' || github.event.changes.base)
     needs:
       - prepareBuildVars
       - testBackend

--- a/.github/workflows/build-alpha.yml
+++ b/.github/workflows/build-alpha.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   prepareBuildVars:
     name: Prepare
-    # Run if the pr is not a draft and the trigger it's a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
+    # Run if the pr is not a draft and the trigger is a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
     if: github.event.pull_request.draft == false && (github.event.action != 'edited' || github.event.changes.base)
     runs-on: ubuntu-24.04
     outputs:
@@ -43,7 +43,7 @@ jobs:
 
   testBackend:
     name: Test Backend
-    # Run if the pr is not a draft and the trigger it's a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
+    # Run if the pr is not a draft and the trigger is a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
     if: github.event.pull_request.draft == false && (github.event.action != 'edited' || github.event.changes.base)
     needs:
       - prepareBuildVars
@@ -55,7 +55,7 @@ jobs:
 
   generateSbom:
     name: SBOM
-    # Run if the pr is not a draft and the trigger it's a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
+    # Run if the pr is not a draft and the trigger is a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
     if: github.event.pull_request.draft == false && (github.event.action != 'edited' || github.event.changes.base)
     needs:
       - prepareBuildVars
@@ -71,7 +71,7 @@ jobs:
 
   genrateLibrary:
     name: Java Library
-    # Run if the pr is not a draft and the trigger it's a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
+    # Run if the pr is not a draft and the trigger is a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
     if: github.event.pull_request.draft == false && (github.event.action != 'edited' || github.event.changes.base)
     needs:
       - prepareBuildVars
@@ -87,7 +87,7 @@ jobs:
 
   generateImage:
     name: Container Image
-    # Run if the pr is not a draft and the build version is valid (not 0.0.0) and the trigger it's a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
+    # Run if the pr is not a draft and the build version is valid (not 0.0.0) and the trigger is a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
     if: github.event.pull_request.draft == false && needs.prepareBuildVars.outputs.build_version != '0.0.0' && (github.event.action != 'edited' || github.event.changes.base)
     needs:
       - prepareBuildVars

--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   prepareBuildVars:
     name: Prepare
-    # Run if the pr is not a draft and the trigger it's a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
+    # Run if the pr is not a draft and the trigger is a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
     if: github.event.pull_request.draft == false && (github.event.action != 'edited' || github.event.changes.base)
     runs-on: ubuntu-24.04
     outputs:
@@ -42,7 +42,7 @@ jobs:
 
   testBackend:
     name: Test Backend
-    # Run if the pr is not a draft and the trigger it's a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
+    # Run if the pr is not a draft and the trigger is a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
     if: github.event.pull_request.draft == false && (github.event.action != 'edited' || github.event.changes.base)
     needs:
       - prepareBuildVars
@@ -54,7 +54,7 @@ jobs:
 
   generateSbom:
     name: SBOM
-    # Run if the pr is not a draft and the trigger it's a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
+    # Run if the pr is not a draft and the trigger is a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
     if: github.event.pull_request.draft == false && (github.event.action != 'edited' || github.event.changes.base)
     needs:
       - prepareBuildVars
@@ -69,7 +69,7 @@ jobs:
 
   genrateLibrary:
     name: Java Library
-    # Run if the pr is not a draft and the trigger it's a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
+    # Run if the pr is not a draft and the trigger is a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
     if: github.event.pull_request.draft == false && (github.event.action != 'edited' || github.event.changes.base)
     needs:
       - prepareBuildVars

--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -13,7 +13,8 @@ on:
 jobs:
   prepareBuildVars:
     name: Prepare
-    if: github.event.pull_request.draft == false
+    # Run if the pr is not a draft and the trigger it's a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
+    if: github.event.pull_request.draft == false && (github.event.action != 'edited' || github.event.changes.base)
     runs-on: ubuntu-24.04
     outputs:
       build_date: ${{ steps.build_date.outputs.value }}
@@ -40,7 +41,8 @@ jobs:
 
   testBackend:
     name: Test Backend
-    if: github.event.pull_request.draft == false
+    # Run if the pr is not a draft and the trigger it's a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
+    if: github.event.pull_request.draft == false && (github.event.action != 'edited' || github.event.changes.base)
     needs:
       - prepareBuildVars
     uses: ./.github/workflows/test-backend.yml
@@ -51,7 +53,8 @@ jobs:
 
   generateSbom:
     name: SBOM
-    if: github.event.pull_request.draft == false
+    # Run if the pr is not a draft and the trigger it's a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
+    if: github.event.pull_request.draft == false && (github.event.action != 'edited' || github.event.changes.base)
     needs:
       - prepareBuildVars
     uses: ./.github/workflows/generate-sbom.yml
@@ -65,7 +68,8 @@ jobs:
 
   genrateLibrary:
     name: Java Library
-    if: github.event.pull_request.draft == false
+    # Run if the pr is not a draft and the trigger it's a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
+    if: github.event.pull_request.draft == false && (github.event.action != 'edited' || github.event.changes.base)
     needs:
       - prepareBuildVars
       - testBackend
@@ -80,7 +84,8 @@ jobs:
 
   generateImage:
     name: Container Image
-    if: github.event.pull_request.draft == false && needs.prepareBuildVars.outputs.build_version != '0.0.0'
+    # Run if the pr is not a draft and the trigger it's a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
+    if: github.event.pull_request.draft == false && (github.event.action != 'edited' || github.event.changes.base)
     needs:
       - prepareBuildVars
       - testBackend

--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -7,6 +7,7 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+      - edited
     branches:
       - "main"
 

--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -85,8 +85,8 @@ jobs:
 
   generateImage:
     name: Container Image
-    # Run if the pr is not a draft and the trigger it's a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
-    if: github.event.pull_request.draft == false && (github.event.action != 'edited' || github.event.changes.base)
+    # Run if the pr is not a draft and the trigger is a normal trigger (open/sync/reopen) OR if it's an 'edited' event where the base branch changed
+    if: github.event.pull_request.draft == false && needs.prepareBuildVars.outputs.build_version != '0.0.0' && (github.event.action != 'edited' || github.event.changes.base)
     needs:
       - prepareBuildVars
       - testBackend


### PR DESCRIPTION
# Description
Currently workflows are not started if the PR is edited (e.g. the base changes). We noticed this behaviour when we had two open PRs.

- PR1: `feature/abc` pointing to base `milestone/5.0.0`
- PR2: `fix/123` pointing to base `feature/abc`

When PR1 was merged into `milestone/5.0.0` the base of PR2 changed from `feature/abc` to `milestone/5.0.0` but the workflows where not triggered.

This PR should fix this behaviour by introducing a new trigger type for pull requests to trigger them whenever the PR is edited but only if the base changes.

# Ticket
- OP#487