### PR TITLE
fix: add environment variables to Gotenberg outbound destinations

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -66,8 +66,8 @@ services:
       API_DOWNLOAD_FROM_DENY_PRIVATE_IPS: "true"
       LIBREOFFICE_DENY_PRIVATE_IPS: "true"
       # Die Allow-List für Gotenberg muss angepasst werden, um die Verbindung zu ihrer Gover-Instanz zu ermöglichen.
-      # Es handelt sich um einen regulären Ausdruck. Bitte achten Sie darauf, dass Punkte als "\\." geschrieben werden müssen und dass der Ausdruck mit ^ beginnt und mit $ endet.
-      CHROMIUM_ALLOW_LIST: "^https://{{ HOSTNAME }}(/|$)"
+      # Es handelt sich um einen regulären Ausdruck. Bitte achten Sie darauf, dass Punkte als "\\." geschrieben werden müssen (z.B. gover\\.aivot\\.de) und dass der Ausdruck mit ^ beginnt und mit $ endet.
+      CHROMIUM_ALLOW_LIST: "^https://{{ HOSTNAME_REGEX }}(/|$)"
     ports:
       - "9191:3000"
     networks:

--- a/compose.yml
+++ b/compose.yml
@@ -62,9 +62,7 @@ services:
     restart: always
     environment:
       CHROMIUM_DENY_PRIVATE_IPS: "true"
-      WEBHOOK_DENY_PRIVATE_IPS: "true"
-      API_DOWNLOAD_FROM_DENY_PRIVATE_IPS: "true"
-      LIBREOFFICE_DENY_PRIVATE_IPS: "true"
+      CHROMIUM_DENY_PUBLIC_IPS: "true"
       # Die Allow-List für Gotenberg muss angepasst werden, um die Verbindung zu ihrer Gover-Instanz zu ermöglichen.
       # Es handelt sich um einen regulären Ausdruck. Bitte achten Sie darauf, dass Punkte als "\\." geschrieben werden müssen (z.B. gover\\.aivot\\.de) und dass der Ausdruck mit ^ beginnt und mit $ endet.
       CHROMIUM_ALLOW_LIST: "^(https://{{ HOSTNAME_REGEX }}|file:///tmp/)"

--- a/compose.yml
+++ b/compose.yml
@@ -60,6 +60,14 @@ services:
   gotenberg:
     image: gotenberg/gotenberg:8
     restart: always
+    environment:
+      CHROMIUM_DENY_PRIVATE_IPS: "true"
+      WEBHOOK_DENY_PRIVATE_IPS: "true"
+      API_DOWNLOAD_FROM_DENY_PRIVATE_IPS: "true"
+      LIBREOFFICE_DENY_PRIVATE_IPS: "true"
+      # Die Allow-List für Gotenberg muss angepasst werden, um die Verbindung zu ihrer Gover-Instanz zu ermöglichen.
+      # Es handelt sich um einen regulären Ausdruck. Bitte achten Sie darauf, dass Punkte als "\\." geschrieben werden müssen und dass der Ausdruck mit ^ beginnt und mit $ endet.
+      CHROMIUM_ALLOW_LIST: "^https://{{ HOSTNAME }}(/|$)"
     ports:
       - "9191:3000"
     networks:

--- a/compose.yml
+++ b/compose.yml
@@ -67,7 +67,7 @@ services:
       LIBREOFFICE_DENY_PRIVATE_IPS: "true"
       # Die Allow-List für Gotenberg muss angepasst werden, um die Verbindung zu ihrer Gover-Instanz zu ermöglichen.
       # Es handelt sich um einen regulären Ausdruck. Bitte achten Sie darauf, dass Punkte als "\\." geschrieben werden müssen (z.B. gover\\.aivot\\.de) und dass der Ausdruck mit ^ beginnt und mit $ endet.
-      CHROMIUM_ALLOW_LIST: "^https://{{ HOSTNAME_REGEX }}(/|$)"
+      CHROMIUM_ALLOW_LIST: "^(https://{{ HOSTNAME_REGEX }}|file:///tmp/)"
     ports:
       - "9191:3000"
     networks:


### PR DESCRIPTION
# Description

This PR implements outbound URL filtering for Gotenberg. This ensures that Gotenberg can only access allowed  resources and is restricted from making unauthorized external network requests.

# Changes

* Configured Gotenberg's outbound URL filtering properties.
* Restricted network connectivity exclusively to endpoints on the same hostname.

# References

* **Documentation:** [[Gotenberg Outbound URL Filtering](https://gotenberg.dev/docs/outbound-url-filtering)](https://gotenberg.dev/docs/outbound-url-filtering)

# Ticket
- OP#868
- OP#487