### PR TITLE
devops: backend build version default

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>de.aivot.gover</groupId>
     <artifactId>backend</artifactId>
-    <version>${env.BUILD_VERSION}</version>
+    <version>${revision}</version>
     <name>gover</name>
     <description>The open source platform for fully digital, end-to-end application processes</description>
     <licenses>
@@ -24,9 +24,24 @@
     </licenses>
 
     <properties>
+        <revision>0.0.0</revision>
         <java.version>21</java.version>
         <graaljs.version>25.0.3</graaljs.version>
     </properties>
+
+    <profiles>
+        <profile>
+            <id>build-version-from-env</id>
+            <activation>
+                <property>
+                    <name>env.BUILD_VERSION</name>
+                </property>
+            </activation>
+            <properties>
+                <revision>${env.BUILD_VERSION}</revision>
+            </properties>
+        </profile>
+    </profiles>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
# Description
Currently all backend maven operations require the presence of the environment variable `BUILD_VERSION`. This is annoying when running maven tasks via the Intellij IDEA maven tool.

This PR resolved this by adding a default version `0.0.0` via the property `revision` and a build profile, activated by the presence of the environment variable `BUILD_VERSION` (which is always present during container image builds) and the corresponding property override in the profile. 