### PR TITLE
feat: ensure busy state is reset after cloning operation

### DIFF
--- a/app/src/components/element-tree-2/components/element-tree-editor.tsx
+++ b/app/src/components/element-tree-2/components/element-tree-editor.tsx
@@ -123,7 +123,11 @@ export function ElementTreeEditor<T extends AnyElement>(props: ElementTreeEditor
 
     const handleClone = () => {
         setIsBusy(true);
-        onClone();
+        try {
+            onClone();
+        } finally {
+            setIsBusy(false);
+        }
     };
 
     const isRoot = root === value;


### PR DESCRIPTION
# Description
When a clone yields a problem, the busy state is never cleared. This PR fixes this issue by adding a try/finally to remove the busy state no matter what the clone yields.

# Tickets
- OP#877