### PR TITLE
fix: empty-layout-element-saving

### DIFF
--- a/app/src/utils/ui-definition-utils.spec.ts
+++ b/app/src/utils/ui-definition-utils.spec.ts
@@ -4,9 +4,25 @@ import {type FormLayoutElement} from '../models/elements/form-layout-element';
 import {generateElementWithDefaultValues} from './generate-element-with-default-values';
 import {normalizeUiDefinitionForStorage} from './ui-definition-utils';
 
+function cloneThroughJson<T>(value: T): T {
+    return JSON.parse(JSON.stringify(value)) as T;
+}
+
 describe('normalizeUiDefinitionForStorage', () => {
     it('normalizes untouched empty generated definitions to null', () => {
         const value = generateElementWithDefaultValues(ElementType.FormLayout) as FormLayoutElement;
+
+        expect(normalizeUiDefinitionForStorage(value)).toBeNull();
+    });
+
+    it('normalizes JSON-cloned empty generated form layouts to null', () => {
+        const value = cloneThroughJson(generateElementWithDefaultValues(ElementType.FormLayout) as FormLayoutElement);
+
+        expect(normalizeUiDefinitionForStorage(value)).toBeNull();
+    });
+
+    it('normalizes JSON-cloned empty generated grouped UI definitions to null', () => {
+        const value = cloneThroughJson(generateElementWithDefaultValues(ElementType.GroupLayout) as GroupLayout);
 
         expect(normalizeUiDefinitionForStorage(value)).toBeNull();
     });

--- a/app/src/utils/ui-definition-utils.spec.ts
+++ b/app/src/utils/ui-definition-utils.spec.ts
@@ -1,0 +1,31 @@
+import {ElementType} from '../data/element-type/element-type';
+import {type GroupLayout} from '../models/elements/form/layout/group-layout';
+import {type FormLayoutElement} from '../models/elements/form-layout-element';
+import {generateElementWithDefaultValues} from './generate-element-with-default-values';
+import {normalizeUiDefinitionForStorage} from './ui-definition-utils';
+
+describe('normalizeUiDefinitionForStorage', () => {
+    it('normalizes untouched empty generated definitions to null', () => {
+        const value = generateElementWithDefaultValues(ElementType.FormLayout) as FormLayoutElement;
+
+        expect(normalizeUiDefinitionForStorage(value)).toBeNull();
+    });
+
+    it('preserves empty form layouts with changed root settings', () => {
+        const value = {
+            ...(generateElementWithDefaultValues(ElementType.FormLayout) as FormLayoutElement),
+            publicTitle: 'Geänderter Titel',
+        };
+
+        expect(normalizeUiDefinitionForStorage(value)).toEqual(value);
+    });
+
+    it('preserves empty grouped UI definitions with changed root settings', () => {
+        const value = {
+            ...(generateElementWithDefaultValues(ElementType.GroupLayout) as GroupLayout),
+            name: 'Geänderte Gruppe',
+        };
+
+        expect(normalizeUiDefinitionForStorage(value)).toEqual(value);
+    });
+});

--- a/app/src/utils/ui-definition-utils.ts
+++ b/app/src/utils/ui-definition-utils.ts
@@ -1,5 +1,34 @@
 import {type AnyElement} from '../models/elements/any-element';
 import {isAnyElementWithChildren} from '../models/elements/any-element-with-children';
+import {deepEquals} from './equality-utils';
+import {generateElementWithDefaultValues} from './generate-element-with-default-values';
+
+function stripGeneratedElementIds(value: unknown): unknown {
+    if (Array.isArray(value)) {
+        return value.map(stripGeneratedElementIds);
+    }
+
+    if (value == null || typeof value !== 'object') {
+        return value;
+    }
+
+    const source = value as Record<string, unknown>;
+    const isElement = 'type' in source;
+
+    return Object.entries(value)
+        .filter(([key]) => key !== 'id' || !isElement)
+        .reduce<Record<string, unknown>>((obj, [key, item]) => {
+            obj[key] = stripGeneratedElementIds(item);
+            return obj;
+        }, {});
+}
+
+function isEmptyGeneratedDefault(value: AnyElement): boolean {
+    const defaultValue = generateElementWithDefaultValues(value.type);
+
+    return defaultValue != null &&
+        deepEquals(stripGeneratedElementIds(value), stripGeneratedElementIds(defaultValue));
+}
 
 export function normalizeUiDefinitionForStorage<T extends AnyElement>(
     value: T | null | undefined
@@ -8,7 +37,11 @@ export function normalizeUiDefinitionForStorage<T extends AnyElement>(
         return null;
     }
 
-    if (isAnyElementWithChildren(value) && (value.children?.length ?? 0) === 0) {
+    if (
+        isAnyElementWithChildren(value) &&
+        (value.children?.length ?? 0) === 0 &&
+        isEmptyGeneratedDefault(value)
+    ) {
         return null;
     }
 

--- a/app/src/utils/ui-definition-utils.ts
+++ b/app/src/utils/ui-definition-utils.ts
@@ -2,10 +2,11 @@ import {type AnyElement} from '../models/elements/any-element';
 import {isAnyElementWithChildren} from '../models/elements/any-element-with-children';
 import {deepEquals} from './equality-utils';
 import {generateElementWithDefaultValues} from './generate-element-with-default-values';
+import {ElementType} from '../data/element-type/element-type';
 
-function stripGeneratedElementIds(value: unknown): unknown {
+function normalizeForDefaultComparison(value: unknown): unknown {
     if (Array.isArray(value)) {
-        return value.map(stripGeneratedElementIds);
+        return value.map(normalizeForDefaultComparison);
     }
 
     if (value == null || typeof value !== 'object') {
@@ -13,12 +14,15 @@ function stripGeneratedElementIds(value: unknown): unknown {
     }
 
     const source = value as Record<string, unknown>;
-    const isElement = 'type' in source;
+    const isElement =
+        typeof source.id === 'string' &&
+        typeof source.type === 'number' &&
+        ElementType[source.type] != null;
 
     return Object.entries(value)
-        .filter(([key]) => key !== 'id' || !isElement)
+        .filter(([key, item]) => item !== undefined && (key !== 'id' || !isElement))
         .reduce<Record<string, unknown>>((obj, [key, item]) => {
-            obj[key] = stripGeneratedElementIds(item);
+            obj[key] = normalizeForDefaultComparison(item);
             return obj;
         }, {});
 }
@@ -27,7 +31,7 @@ function isEmptyGeneratedDefault(value: AnyElement): boolean {
     const defaultValue = generateElementWithDefaultValues(value.type);
 
     return defaultValue != null &&
-        deepEquals(stripGeneratedElementIds(value), stripGeneratedElementIds(defaultValue));
+        deepEquals(normalizeForDefaultComparison(value), normalizeForDefaultComparison(defaultValue));
 }
 
 export function normalizeUiDefinitionForStorage<T extends AnyElement>(


### PR DESCRIPTION
# Description
When changing only the layout element in the form node editor or the ui definition editor the change is not correctly detected. This PR fixes this problem by extending the ui definition normalization with a comparison to the generated base of an element.

# Tickets
- OP#896