### PR TITLE
fix(forms): prevent navigation past invalid summary and submit steps

### DIFF
--- a/app/src/components/form/root.component.view.tsx
+++ b/app/src/components/form/root.component.view.tsx
@@ -25,7 +25,6 @@ import {useRootStructureActionsContext} from './root-structure-actions-context';
 import {UiDefinitionEmptyState} from '../ui-definition-empty-state/ui-definition-empty-state';
 import {useViewDispatcherContext, ViewDispatcherMode} from '../view-dispatcher/view-dispatcher.context';
 import {ViewDispatcherComponent} from '../view-dispatcher/view-dispatcher.component';
-import {isAnyElementWithChildren} from '../../models/elements/any-element-with-children';
 
 export const SUBMIT_EVENT = 'submit';
 
@@ -141,8 +140,10 @@ export function RootComponentView(props: BaseViewProps<FormLayoutElement, void>)
             (children ?? []).filter((step) => step.id !== currentStepElement.id).map((step) => step.id),
         );
 
-        const currentPageHasErrors = isAnyElementWithChildren(currentStepElement) &&
-            hasAnyErrorRecursivelyInParent(currentStepElement, derivationData.elementStates);
+        const currentPageHasErrors = hasAnyErrorRecursivelyInParent(
+            currentStepElement,
+            derivationData.elementStates,
+        );
         if (currentPageHasErrors) {
             setIsBusyNavigating(false);
             setHasSteppedOnce(true);

--- a/app/src/models/element-data.spec.ts
+++ b/app/src/models/element-data.spec.ts
@@ -21,6 +21,23 @@ describe('hasAuthoredElementValuesSomeInput', () => {
 });
 
 describe('hasAnyErrorRecursivelyInParent', () => {
+    it.each([
+        ElementType.SummaryStep,
+        ElementType.SubmitStep,
+    ])('should detect an error on a childless form step of type %s', (type) => {
+        const step = {
+            id: 'childless-step',
+            type,
+        } as any;
+        const elementStates: ComputedElementStates = {
+            'childless-step': {
+                error: 'Step error',
+            },
+        };
+
+        expect(hasAnyErrorRecursivelyInParent(step, elementStates)).toBe(true);
+    });
+
     it('should detect an error on the parent itself', () => {
         const parent = {
             id: 'parent',

--- a/app/src/models/element-data.ts
+++ b/app/src/models/element-data.ts
@@ -1,6 +1,6 @@
 import type {AnyElement} from './elements/any-element';
 import {isStringNotNullOrEmpty} from '../utils/string-utils';
-import {type AnyElementWithChildren, isAnyElementWithChildren} from './elements/any-element-with-children';
+import {isAnyElementWithChildren} from './elements/any-element-with-children';
 import {isReplicatingContainerLayout} from './elements/form/layout/replicating-container-layout';
 
 export type AuthoredElementValues = Partial<Record<string, any>>;
@@ -184,7 +184,7 @@ export function hasAnyErrorRecursively(elementStates: ComputedElementStates): bo
         });
 }
 
-export function hasAnyErrorRecursivelyInParent(parent: AnyElementWithChildren, allElementStates: ComputedElementStates): boolean {
+export function hasAnyErrorRecursivelyInParent(parent: AnyElement, allElementStates: ComputedElementStates): boolean {
     return hasAnyErrorRecursivelyInElement(parent, allElementStates);
 }
 


### PR DESCRIPTION
## Summary

- prevent stepper navigation when the summary confirmation is missing
- prevent form submission when the CAPTCHA validation fails
- include validation errors located directly on childless form steps
- add regression tests for summary and submit steps

## Root cause

The stepper only checked validation errors when the current step was classified as an element with children. Summary and submit steps do not have children, so their own validation errors were displayed but did not block navigation or submission.