### PR TITLE
feat(system-roles): make most privileged role configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ docker compose up -d
 Gover staff users are managed in Keycloak and imported into Gover when they log in for the first time.
 The Keycloak admin account from the Docker Compose configuration is only used to manage Keycloak; it is not automatically a Gover administrator.
 
-Before the first Gover login, decide which staff user should become the initial Gover super administrator.
+Before the first Gover login, decide which staff user should receive Gover's system role with the highest permission level.
 Add that user's e-mail address to the `gover` service environment in your `compose.yml`:
 
 ```yaml
@@ -92,7 +92,8 @@ After saving the user, open the "Credentials" tab and set a password.
 Disable "Temporary" if the user should keep this password after the first login.
 
 When this user logs into Gover for the first time, Gover imports the Keycloak user.
-If no Gover super administrator exists yet and the e-mail address matches `GOVER_BOOTSTRAP_ADMIN_MAIL`, the user receives the `Superadministrator:in` system role.
+If no active Gover user holds the configured system role with the highest permission level and the e-mail address matches `GOVER_BOOTSTRAP_ADMIN_MAIL`, the user receives that role.
+The role defaults to `Superadministrator:in` and can later be changed under the general application settings.
 
 #### Logging into Gover
 
@@ -101,7 +102,7 @@ Gover redirects staff logins to the Keycloak `staff` realm.
 Sign in with the staff user created above and complete any required Keycloak actions, such as changing a temporary password.
 
 After the Keycloak login succeeds, you are redirected back to the Gover staff application.
-If the user can log in but does not have administrator permissions, verify that the user was created in the `staff` realm, that the user's e-mail address matches `GOVER_BOOTSTRAP_ADMIN_MAIL`, and that no other Gover super administrator existed before this user was imported.
+If the user can log in but does not have administrator permissions, verify that the user was created in the `staff` realm, that the user's e-mail address matches `GOVER_BOOTSTRAP_ADMIN_MAIL`, and that no other active Gover user already holds the configured system role with the highest permission level.
 
 ## Development Setup
 Refer to the [development setup instructions](./development/README.md) for setting up Gover for development.

--- a/app/src/data/system-config-keys.ts
+++ b/app/src/data/system-config-keys.ts
@@ -21,6 +21,9 @@ export const SystemConfigKeys = {
     users: {
         defaultSystemRole: 'users.default_system_role',
     },
+    systemRoles: {
+        mostPrivilegedRole: 'system_roles.most_privileged_role',
+    },
     storage: {
         assets: {
             default_storage_provider: 'storage.assets.default_storage_provider',

--- a/app/src/modules/system/components/most-privileged-system-role-badge.tsx
+++ b/app/src/modules/system/components/most-privileged-system-role-badge.tsx
@@ -1,0 +1,61 @@
+import HelpOutlineIcon from '@aivot/mui-material-symbols-400-n25-outlined/Help';
+import {Box, type SxProps, type Theme} from '@mui/material';
+import React from 'react';
+import {Chip} from '../../../components/chip/chip';
+import {HintTooltip} from '../../../components/hint-tooltip/hint-tooltip';
+
+const MOST_PRIVILEGED_SYSTEM_ROLE_HINT = 'Diese Rolle ist in den Systemeinstellungen als Systemrolle mit der höchsten Berechtigungsstufe festgelegt.';
+
+interface MostPrivilegedSystemRoleBadgeProps {
+    showHintIcon?: boolean;
+    sx?: SxProps<Theme>;
+}
+
+export function isMostPrivilegedSystemRole(
+    roleId: number | string | undefined,
+    mostPrivilegedSystemRoleId: string | undefined,
+): boolean {
+    return roleId != null &&
+        mostPrivilegedSystemRoleId != null &&
+        mostPrivilegedSystemRoleId.trim().length > 0 &&
+        roleId.toString() === mostPrivilegedSystemRoleId.trim();
+}
+
+export function MostPrivilegedSystemRoleBadge(props: MostPrivilegedSystemRoleBadgeProps) {
+    const label = props.showHintIcon
+        ? (
+            <Box
+                component="span"
+                sx={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 0.5,
+                }}
+            >
+                Höchste Berechtigungsstufe
+                <HelpOutlineIcon sx={{fontSize: 16}}/>
+            </Box>
+        )
+        : 'Höchste Berechtigungsstufe';
+
+    return (
+        <HintTooltip
+            arrow
+            placement="top"
+            title={MOST_PRIVILEGED_SYSTEM_ROLE_HINT}
+        >
+            <Box
+                component="span"
+                sx={props.sx}
+            >
+                <Chip
+                    component="span"
+                    label={label}
+                    color="warning"
+                    mode="soft"
+                    size="small"
+                />
+            </Box>
+        </HintTooltip>
+    );
+}

--- a/app/src/modules/system/pages/details/system-roles-details-page-index.tsx
+++ b/app/src/modules/system/pages/details/system-roles-details-page-index.tsx
@@ -58,6 +58,7 @@ export function SystemRolesDetailsPageIndex(): ReactNode {
     const dispatch = useAppDispatch();
     const navigate = useNavigate();
     const defaultSystemRoleId = useAppSelector(selectSystemConfigValue(SystemConfigKeys.users.defaultSystemRole));
+    const mostPrivilegedSystemRoleId = useAppSelector(selectSystemConfigValue(SystemConfigKeys.systemRoles.mostPrivilegedRole));
 
     const {
         item: systemRole,
@@ -113,8 +114,13 @@ export function SystemRolesDetailsPageIndex(): ReactNode {
         defaultSystemRoleId != null &&
         defaultSystemRoleId.trim().length > 0 &&
         String(currentSystemRoleId) === defaultSystemRoleId.trim();
+    const isMostPrivilegedSystemRole =
+        currentSystemRoleId !== 0 &&
+        mostPrivilegedSystemRoleId != null &&
+        mostPrivilegedSystemRoleId.trim().length > 0 &&
+        String(currentSystemRoleId) === mostPrivilegedSystemRoleId.trim();
     const hasAssignedUsers = (assignedUsersCount ?? 0) > 0;
-    const requiresReplacementSystemRole = isDefaultSystemRole || hasAssignedUsers;
+    const requiresReplacementSystemRole = isDefaultSystemRole || isMostPrivilegedSystemRole || hasAssignedUsers;
 
     useEffect(() => {
         if (currentSystemRoleId === 0 || !canDeleteSystemRole) {
@@ -286,6 +292,11 @@ export function SystemRolesDetailsPageIndex(): ReactNode {
             'Diese Rolle ist aktuell als Standard-Systemrolle für automatische Benutzerimporte konfiguriert. Beim Löschen wird diese Einstellung ebenfalls auf die ausgewählte Ersatz-Systemrolle geändert.',
         );
     }
+    if (isMostPrivilegedSystemRole) {
+        deleteImpactTexts.push(
+            'Diese Rolle ist aktuell als Systemrolle mit der höchsten Berechtigungsstufe konfiguriert. Beim Löschen wird diese Einstellung auf die ausgewählte Ersatz-Systemrolle geändert.',
+        );
+    }
     const saveDisabledByPermission = !isEditable;
     const saveDisabledTooltip = saveDisabledByPermission
         ? formatMissingPermissionTooltip(editPermission)
@@ -364,6 +375,10 @@ export function SystemRolesDetailsPageIndex(): ReactNode {
         const migratedUsersCount = hasAssignedUsers ? (assignedUsersCount ?? 0) : 0;
         const defaultSystemRoleWillBeUpdated = isDefaultSystemRole && replacementSystemRoleId != null;
         const newDefaultSystemRoleId = defaultSystemRoleWillBeUpdated ? Number(replacementSystemRoleId) : null;
+        const mostPrivilegedSystemRoleWillBeUpdated = isMostPrivilegedSystemRole && replacementSystemRoleId != null;
+        const newMostPrivilegedSystemRoleId = mostPrivilegedSystemRoleWillBeUpdated
+            ? Number(replacementSystemRoleId)
+            : null;
 
         setIsBusy(true);
 
@@ -380,6 +395,13 @@ export function SystemRolesDetailsPageIndex(): ReactNode {
                         publicConfig: false,
                     }));
                 }
+                if (mostPrivilegedSystemRoleWillBeUpdated && newMostPrivilegedSystemRoleId != null) {
+                    dispatch(setSystemConfig({
+                        key: SystemConfigKeys.systemRoles.mostPrivilegedRole,
+                        value: String(newMostPrivilegedSystemRoleId),
+                        publicConfig: false,
+                    }));
+                }
 
                 const successMessages = ['Die Systemrolle wurde erfolgreich gelöscht.'];
                 if (migratedUsersCount > 0 && replacementRole != null) {
@@ -390,6 +412,11 @@ export function SystemRolesDetailsPageIndex(): ReactNode {
                 if (defaultSystemRoleWillBeUpdated && replacementRole != null) {
                     successMessages.push(
                         `Die Standard-Systemrolle für automatische Benutzerimporte wurde auf „${replacementRole.label}“ gesetzt.`,
+                    );
+                }
+                if (mostPrivilegedSystemRoleWillBeUpdated && replacementRole != null) {
+                    successMessages.push(
+                        `Die Systemrolle mit der höchsten Berechtigungsstufe wurde auf „${replacementRole.label}“ gesetzt.`,
                     );
                 }
 
@@ -576,14 +603,14 @@ export function SystemRolesDetailsPageIndex(): ReactNode {
                             options={systemRoleOptions}
                             required
                             disabled={isBusy || isSystemRolesLoading}
-                            hint="Alle betroffenen Mitarbeiter:innen und gegebenenfalls die Systemeinstellung für automatische Benutzerimporte werden auf diese Rolle umgestellt."
+                            hint="Alle betroffenen Mitarbeiter:innen und Systemeinstellungen werden auf diese Rolle umgestellt."
                             emptyStatePlaceholder="Keine Ersatz-Systemrolle verfügbar"
                         />
                     </>
                 ) : (
                     <AlertComponent color="info">
-                        Diese Systemrolle ist aktuell keiner Mitarbeiter:in zugeordnet und nicht als Standard-Systemrolle
-                        für automatische Benutzerimporte konfiguriert.
+                        Diese Systemrolle ist aktuell keiner Mitarbeiter:in zugeordnet und in keiner Rolleneinstellung
+                        konfiguriert.
                     </AlertComponent>
                 )}
             </ConfirmDialog>

--- a/app/src/modules/system/pages/details/system-roles-details-page.tsx
+++ b/app/src/modules/system/pages/details/system-roles-details-page.tsx
@@ -1,5 +1,5 @@
 import {PageWrapper} from '../../../../components/page-wrapper/page-wrapper';
-import {Typography} from '@mui/material';
+import {Box, Typography} from '@mui/material';
 import {GenericDetailsPage} from '../../../../components/generic-details-page/generic-details-page';
 import React from 'react';
 import {ServerEntityType} from '../../../../shells/staff/data/server-entity-type';
@@ -14,9 +14,14 @@ import {
     isDefaultUserSystemRole,
 } from '../../components/default-user-system-role-badge';
 import {Permission} from '../../../../data/permissions/permission';
+import {
+    isMostPrivilegedSystemRole,
+    MostPrivilegedSystemRoleBadge,
+} from '../../components/most-privileged-system-role-badge';
 
 export function SystemRolesDetailsPage() {
     const defaultSystemRoleId = useAppSelector(selectSystemConfigValue(SystemConfigKeys.users.defaultSystemRole));
+    const mostPrivilegedSystemRoleId = useAppSelector(selectSystemConfigValue(SystemConfigKeys.systemRoles.mostPrivilegedRole));
 
     return (
         <PageWrapper
@@ -36,8 +41,21 @@ export function SystemRolesDetailsPage() {
                 header={(item, isNewItem, notFound) => ({
                     icon: ModuleIcons.roles,
                     title: 'Systemrolle bearbeiten',
-                    badge: !isNewItem && !notFound && isDefaultUserSystemRole(item?.id, defaultSystemRoleId)
-                        ? <DefaultUserSystemRoleBadge showHintIcon />
+                    badge: !isNewItem && !notFound && (
+                        isDefaultUserSystemRole(item?.id, defaultSystemRoleId) ||
+                        isMostPrivilegedSystemRole(item?.id, mostPrivilegedSystemRoleId)
+                    )
+                        ? (
+                            <Box
+                                component="span"
+                                sx={{display: 'inline-flex', flexWrap: 'wrap', gap: 1}}
+                            >
+                                {isDefaultUserSystemRole(item?.id, defaultSystemRoleId) &&
+                                    <DefaultUserSystemRoleBadge showHintIcon/>}
+                                {isMostPrivilegedSystemRole(item?.id, mostPrivilegedSystemRoleId) &&
+                                    <MostPrivilegedSystemRoleBadge showHintIcon/>}
+                            </Box>
+                        )
                         : undefined,
                     helpDialog: {
                         title: 'Hilfe zu Systemrollen',

--- a/app/src/modules/system/pages/list/system-roles-list-page.tsx
+++ b/app/src/modules/system/pages/list/system-roles-list-page.tsx
@@ -24,6 +24,10 @@ import {
 } from '../../components/default-user-system-role-badge';
 import {GenericListPropsFetchOptions} from '../../../../components/generic-list/generic-list-props';
 import {Permission} from '../../../../data/permissions/permission';
+import {
+    isMostPrivilegedSystemRole,
+    MostPrivilegedSystemRoleBadge,
+} from '../../components/most-privileged-system-role-badge';
 
 const systemRolesListPermissionCheck: GenericListPagePermissionConfig<SystemRoleEntity> = {
     scope: {
@@ -37,6 +41,7 @@ const systemRolesListPermissionCheck: GenericListPagePermissionConfig<SystemRole
 export function SystemRolesListPage() {
     const navigate = useNavigate();
     const defaultSystemRoleId = useAppSelector(selectSystemConfigValue(SystemConfigKeys.users.defaultSystemRole));
+    const mostPrivilegedSystemRoleId = useAppSelector(selectSystemConfigValue(SystemConfigKeys.systemRoles.mostPrivilegedRole));
 
     const header = useCallback((permissions: GenericListPagePermissionState<SystemRoleEntity>) => ({
         icon: ModuleIcons.roles,
@@ -98,16 +103,16 @@ export function SystemRolesListPage() {
             headerName: 'Name',
             flex: 1,
             renderCell: (params: any) => {
-                const badge = isDefaultUserSystemRole(params.row.id, defaultSystemRoleId) &&
-                    <DefaultUserSystemRoleBadge sx={{ml: 1}} />;
-
                 return (
                     <CellLink
                         to={`/system-roles/${params.id}`}
                         title={permissions.canUpdate(params.row) ? 'Systemrolle bearbeiten' : 'Systemrolle anzeigen'}
                     >
                         {String(params.value)}
-                        {badge}
+                        {isDefaultUserSystemRole(params.row.id, defaultSystemRoleId) &&
+                            <DefaultUserSystemRoleBadge sx={{ml: 1}}/>}
+                        {isMostPrivilegedSystemRole(params.row.id, mostPrivilegedSystemRoleId) &&
+                            <MostPrivilegedSystemRoleBadge sx={{ml: 1}}/>}
                     </CellLink>
                 );
             },
@@ -117,7 +122,7 @@ export function SystemRolesListPage() {
             headerName: 'Beschreibung',
             flex: 2,
         },
-    ], [defaultSystemRoleId]);
+    ], [defaultSystemRoleId, mostPrivilegedSystemRoleId]);
 
     const getRowIdentifier = useCallback((row: SystemRoleEntity) => row.id.toString(), []);
 

--- a/app/src/pages/staff-pages/settings/components/application-settings/application-settings.tsx
+++ b/app/src/pages/staff-pages/settings/components/application-settings/application-settings.tsx
@@ -31,6 +31,7 @@ import {DepartmentSelectField} from '../../../../../modules/departments/componen
 import {ModuleIcons} from '../../../../../shells/staff/data/module-icons';
 import Label from '@aivot/mui-material-symbols-400-n25-outlined/Label';
 import SupervisedUserCircle from '@aivot/mui-material-symbols-400-n25-outlined/SupervisedUserCircle';
+import AdminPanelSettings from '@aivot/mui-material-symbols-400-n25-outlined/AdminPanelSettings';
 import {
     SystemConfigDefinitionResponseDTO,
 } from '../../../../../modules/configs/dtos/system-config-definition-response-dto';
@@ -88,9 +89,11 @@ export function ApplicationSettings() {
 
     const hasNotChanged = Object.keys(editedConfig).length === 0;
     const configuredDefaultSystemRole = config[SystemConfigKeys.users.defaultSystemRole];
+    const configuredMostPrivilegedSystemRole = config[SystemConfigKeys.systemRoles.mostPrivilegedRole];
     const configuredAssetStorageProvider = config[SystemConfigKeys.storage.assets.default_storage_provider];
     const configuredAttachmentStorageProvider = config[SystemConfigKeys.storage.attachments.default_storage_provider];
     const defaultSystemRoleValue = editedConfig[SystemConfigKeys.users.defaultSystemRole] ?? configuredDefaultSystemRole;
+    const mostPrivilegedSystemRoleValue = editedConfig[SystemConfigKeys.systemRoles.mostPrivilegedRole] ?? configuredMostPrivilegedSystemRole;
     const assetStorageProviderValue = editedConfig[SystemConfigKeys.storage.assets.default_storage_provider] ?? configuredAssetStorageProvider;
     const attachmentStorageProviderValue = editedConfig[SystemConfigKeys.storage.attachments.default_storage_provider] ?? configuredAttachmentStorageProvider;
     const getConfiguredDepartment = (key: string): VDepartmentShadowedEntity | null => {
@@ -112,6 +115,14 @@ export function ApplicationSettings() {
                 ? 'Es ist keine Systemrolle vorhanden. Legen Sie zuerst eine Systemrolle an.'
                 : isStringNullOrEmpty(defaultSystemRoleValue)
                     ? 'Bitte wählen Sie eine Standard-Systemrolle aus.'
+                    : undefined
+            : undefined;
+    const mostPrivilegedSystemRoleError =
+        canReadSystemRoles && !isLoadingSystemRoles
+            ? systemRoleOptions.length === 0
+                ? 'Es ist keine Systemrolle vorhanden. Legen Sie zuerst eine Systemrolle an.'
+                : isStringNullOrEmpty(mostPrivilegedSystemRoleValue)
+                    ? 'Bitte wählen Sie die Systemrolle mit der höchsten Berechtigungsstufe aus.'
                     : undefined
             : undefined;
     const assetStorageProviderError =
@@ -383,6 +394,20 @@ export function ApplicationSettings() {
                 }
 
                 dispatch(showErrorSnackbar('Bitte wählen Sie eine Standard-Systemrolle für automatische Benutzerimporte aus.'));
+                return;
+            }
+
+            const currentMostPrivilegedSystemRole =
+                normalizedEditedConfig[SystemConfigKeys.systemRoles.mostPrivilegedRole] ??
+                config[SystemConfigKeys.systemRoles.mostPrivilegedRole];
+
+            if (canReadSystemRoles && isStringNullOrEmpty(currentMostPrivilegedSystemRole)) {
+                if (systemRoleOptions.length === 0) {
+                    dispatch(showErrorSnackbar('Für die höchste Berechtigungsstufe muss mindestens eine Systemrolle vorhanden sein. Legen Sie zuerst eine Systemrolle an.'));
+                    return;
+                }
+
+                dispatch(showErrorSnackbar('Bitte wählen Sie die Systemrolle mit der höchsten Berechtigungsstufe aus.'));
                 return;
             }
 
@@ -796,7 +821,7 @@ export function ApplicationSettings() {
                         mt: 4,
                     }}
                 >
-                    Automatische Rollenzuweisung
+                    Systemrollen
                 </Typography>
                 <Typography
                     sx={{
@@ -804,9 +829,8 @@ export function ApplicationSettings() {
                         mb: 1.6,
                     }}
                 >
-                    Wählen Sie hier die Systemrolle aus, die Mitarbeiter:innen automatisch erhalten sollen, wenn sie neu
-                    in
-                    Gover synchronisiert oder anderweitig importiert werden.
+                    Legen Sie fest, welche Systemrollen bei automatischen Benutzerimporten verwendet werden und welche
+                    Rolle systemweit als höchste Berechtigungsstufe gilt.
                 </Typography>
                 <Grid
                     container
@@ -848,6 +872,44 @@ export function ApplicationSettings() {
                                         : 'Keine Systemrollen vorhanden'
                             }
                             startIcon={<SupervisedUserCircle/>}
+                        />
+                    </Grid>
+                    <Grid
+                        size={{
+                            xs: 12,
+                            lg: 6,
+                        }}
+                    >
+                        <SelectFieldComponent
+                            label="Systemrolle mit höchster Berechtigungsstufe"
+                            hint={
+                                !canReadSystemRoles
+                                    ? systemRoleReadHint
+                                    : hasSystemRolesLoadingError
+                                    ? 'Die Systemrollen konnten nicht geladen werden. Bitte laden Sie die Seite neu oder prüfen Sie Ihre Berechtigungen.'
+                                    : 'Diese Systemrolle gilt in Gover als höchste Berechtigungsstufe. Besitzt keine aktive Mitarbeiter:in diese Rolle, wird sie automatisch dem Administrationskonto zugewiesen, dessen E-Mail-Adresse über die Umgebungsvariable GOVER_BOOTSTRAP_ADMIN_MAIL konfiguriert ist.'
+                            }
+                            value={mostPrivilegedSystemRoleValue}
+                            onChange={(val) => {
+                                setEditedConfig({
+                                    ...editedConfig,
+                                    [SystemConfigKeys.systemRoles.mostPrivilegedRole]: val ?? '',
+                                });
+                            }}
+                            required
+                            error={mostPrivilegedSystemRoleError}
+                            disabled={!canUpdateSystemConfig || !canReadSystemRoles || isLoadingSystemRoles}
+                            options={systemRoleOptions}
+                            emptyStatePlaceholder={
+                                !canReadSystemRoles
+                                    ? 'Keine Berechtigung zur Einsicht'
+                                    : isLoadingSystemRoles
+                                    ? 'Systemrollen werden geladen…'
+                                    : hasSystemRolesLoadingError
+                                        ? 'Systemrollen konnten nicht geladen werden'
+                                        : 'Keine Systemrollen vorhanden'
+                            }
+                            startIcon={<AdminPanelSettings/>}
                         />
                     </Grid>
                 </Grid>

--- a/backend/src/main/java/de/aivot/gover/backend/user/repositories/UserRepository.java
+++ b/backend/src/main/java/de/aivot/gover/backend/user/repositories/UserRepository.java
@@ -14,6 +14,15 @@ public interface UserRepository extends JpaRepository<UserEntity, String>, JpaSp
 
     Boolean existsBySystemRoleId(Integer systemRoleId);
 
+    @Query("""
+            SELECT CASE WHEN COUNT(u) > 0 THEN TRUE ELSE FALSE END
+            FROM UserEntity u
+            WHERE u.systemRoleId = :systemRoleId
+              AND u.enabled = TRUE
+              AND u.deletedInIdp = FALSE
+            """)
+    boolean existsActiveUserBySystemRoleId(@Param("systemRoleId") Integer systemRoleId);
+
     boolean existsByEmail(String email);
 
     List<UserEntity> findAllBySystemRoleIdOrderByFullNameAsc(Integer systemRoleId);

--- a/backend/src/main/java/de/aivot/gover/backend/user/services/ImportedUserSystemRoleService.java
+++ b/backend/src/main/java/de/aivot/gover/backend/user/services/ImportedUserSystemRoleService.java
@@ -5,7 +5,7 @@ import de.aivot.gover.backend.lib.exceptions.ResponseException;
 import de.aivot.gover.backend.models.config.GoverConfig;
 import de.aivot.gover.backend.user.configs.DefaultUserSystemRoleSystemConfigDefinition;
 import de.aivot.gover.backend.user.repositories.UserRepository;
-import de.aivot.gover.backend.userRoles.entities.SystemRoleEntity;
+import de.aivot.gover.backend.userRoles.configs.MostPrivilegedSystemRoleSystemConfigDefinition;
 import de.aivot.gover.backend.userRoles.repositories.SystemRoleRepository;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Service;
  * <p>This keeps the import policy in one place so the scheduled sync and the
  * first-login import use the same rules:
  * <ul>
- *   <li>promote the configured bootstrap admin mail to super-admin if none exists yet</li>
+ *   <li>promote the configured bootstrap admin mail to the most privileged role if no active user holds it</li>
  *   <li>otherwise keep an already assigned system role</li>
  *   <li>otherwise assign the configured default imported-user role</li>
  * </ul>
@@ -51,17 +51,17 @@ public class ImportedUserSystemRoleService {
      * Result of resolving the target system role for an imported user.
      *
      * @param systemRoleId The role that should be stored on the user.
-     * @param promotedToSuperAdmin Whether the resolution newly promoted the user to super-admin.
+     * @param promotedToMostPrivilegedRole Whether the resolution newly promoted the user to the most privileged role.
      */
     public record ImportedUserSystemRoleResolution(
             @Nullable Integer systemRoleId,
-            boolean promotedToSuperAdmin
+            boolean promotedToMostPrivilegedRole
     ) {
     }
 
     /**
      * Resolves the imported user's target role using the currently configured default role,
-     * the current super-admin role, and the current super-admin presence in the database.
+     * the most privileged role, and whether an active user currently holds that role.
      */
     @Nonnull
     public ImportedUserSystemRoleResolution resolveSystemRoleId(
@@ -69,28 +69,37 @@ public class ImportedUserSystemRoleService {
             @Nullable Integer currentSystemRoleId
     ) throws ResponseException {
         var defaultSystemRoleId = getDefaultSystemRoleId();
-        var superAdminRoleId = getSuperAdminRoleId();
-        var hasSuperAdmin = hasSuperAdminUser(superAdminRoleId);
+        var mostPrivilegedSystemRoleId = getMostPrivilegedSystemRoleId();
+        var hasActiveUserWithMostPrivilegedRole = hasActiveUserWithMostPrivilegedRole(mostPrivilegedSystemRoleId);
 
-        return resolveSystemRoleId(email, currentSystemRoleId, defaultSystemRoleId, superAdminRoleId, hasSuperAdmin);
+        return resolveSystemRoleId(
+                email,
+                currentSystemRoleId,
+                defaultSystemRoleId,
+                mostPrivilegedSystemRoleId,
+                hasActiveUserWithMostPrivilegedRole
+        );
     }
 
     /**
      * Resolves the imported user's target role from already prepared inputs.
      *
      * <p>This overload is primarily useful for sync flows and tests that already know
-     * the default role id, the super-admin role id, and whether a super-admin exists.
+     * the default role id, the most privileged role id, and whether an active user holds that role.
      */
     @Nonnull
     public ImportedUserSystemRoleResolution resolveSystemRoleId(
             @Nullable String email,
             @Nullable Integer currentSystemRoleId,
             @Nonnull Integer defaultSystemRoleId,
-            @Nullable Integer superAdminRoleId,
-            boolean hasSuperAdmin
+            @Nonnull Integer mostPrivilegedSystemRoleId,
+            boolean hasActiveUserWithMostPrivilegedRole
     ) {
-        if (!hasSuperAdmin && superAdminRoleId != null && isBootstrapAdmin(email)) {
-            return new ImportedUserSystemRoleResolution(superAdminRoleId, !superAdminRoleId.equals(currentSystemRoleId));
+        if (!hasActiveUserWithMostPrivilegedRole && isBootstrapAdmin(email)) {
+            return new ImportedUserSystemRoleResolution(
+                    mostPrivilegedSystemRoleId,
+                    !mostPrivilegedSystemRoleId.equals(currentSystemRoleId)
+            );
         }
 
         if (currentSystemRoleId != null) {
@@ -121,22 +130,31 @@ public class ImportedUserSystemRoleService {
     }
 
     /**
-     * Returns the role currently treated as super-admin, based on the role with the
-     * largest permission set.
+     * Reads the system role configured as the highest permission level and ensures
+     * that it still references an existing role.
      */
-    @Nullable
-    public Integer getSuperAdminRoleId() {
-        return systemRoleRepository
-                .findByMaxPermissions()
-                .map(SystemRoleEntity::getId)
-                .orElse(null);
+    @Nonnull
+    public Integer getMostPrivilegedSystemRoleId() throws ResponseException {
+        var configEntity = systemConfigService
+                .retrieve(MostPrivilegedSystemRoleSystemConfigDefinition.KEY);
+
+        var systemRoleId = configEntity
+                .getValueAsInteger()
+                .orElseThrow(() -> ResponseException.internalServerError("Die konfigurierte Systemrolle mit der höchsten Berechtigungsstufe ist ungültig."));
+
+        if (!systemRoleRepository.existsById(systemRoleId)) {
+            throw ResponseException.internalServerError("Die konfigurierte Systemrolle mit der höchsten Berechtigungsstufe existiert nicht.");
+        }
+
+        return systemRoleId;
     }
 
     /**
-     * Checks whether any user currently holds the resolved super-admin role.
+     * Checks whether an enabled user that still exists in the identity provider
+     * currently holds the most privileged role.
      */
-    public boolean hasSuperAdminUser(@Nullable Integer superAdminRoleId) {
-        return superAdminRoleId != null && userRepository.existsBySystemRoleId(superAdminRoleId);
+    public boolean hasActiveUserWithMostPrivilegedRole(@Nonnull Integer mostPrivilegedSystemRoleId) {
+        return userRepository.existsActiveUserBySystemRoleId(mostPrivilegedSystemRoleId);
     }
 
     private boolean isBootstrapAdmin(@Nullable String email) {

--- a/backend/src/main/java/de/aivot/gover/backend/user/services/UserSyncService.java
+++ b/backend/src/main/java/de/aivot/gover/backend/user/services/UserSyncService.java
@@ -49,7 +49,7 @@ public class UserSyncService {
         var totalUsersFromIdp = 0;
         var importedOrUpdatedCount = 0;
         var deletedInIdpCount = 0;
-        var promotedToSuperAdminCount = 0;
+        var promotedToMostPrivilegedRoleCount = 0;
 
         var success = true;
         String failureMessage = null;
@@ -57,8 +57,9 @@ public class UserSyncService {
 
         try {
             var defaultSystemRoleId = importedUserSystemRoleService.getDefaultSystemRoleId();
-            var superRoleId = importedUserSystemRoleService.getSuperAdminRoleId();
-            var hasSuperAdmin = importedUserSystemRoleService.hasSuperAdminUser(superRoleId);
+            var mostPrivilegedSystemRoleId = importedUserSystemRoleService.getMostPrivilegedSystemRoleId();
+            var hasActiveUserWithMostPrivilegedRole = importedUserSystemRoleService
+                    .hasActiveUserWithMostPrivilegedRole(mostPrivilegedSystemRoleId);
 
             var alreadyImportedUsers = userRepository
                     .findAll();
@@ -108,15 +109,15 @@ public class UserSyncService {
                         userEntity.getEmail(),
                         userEntity.getSystemRoleId(),
                         defaultSystemRoleId,
-                        superRoleId,
-                        hasSuperAdmin
+                        mostPrivilegedSystemRoleId,
+                        hasActiveUserWithMostPrivilegedRole
                 );
                 var systemRoleChanged = !Objects.equals(userEntity.getSystemRoleId(), roleResolution.systemRoleId());
                 userEntity.setSystemRoleId(roleResolution.systemRoleId());
 
-                if (roleResolution.promotedToSuperAdmin()) {
-                    promotedToSuperAdminCount++;
-                    hasSuperAdmin = true;
+                if (roleResolution.promotedToMostPrivilegedRole()) {
+                    promotedToMostPrivilegedRoleCount++;
+                    hasActiveUserWithMostPrivilegedRole = true;
                 }
 
                 var hasChanged = isCreate || dataChanged || systemRoleChanged;
@@ -133,7 +134,7 @@ public class UserSyncService {
                             "verified", userEntity.getVerified(),
                             "deletedInIdp", userEntity.getDeletedInIdp(),
                             "action", isCreate ? "imported" : "updated",
-                            "promotedToSuperAdmin", roleResolution.promotedToSuperAdmin()
+                            "promotedToMostPrivilegedRole", roleResolution.promotedToMostPrivilegedRole()
                     ));
                 }
 
@@ -167,7 +168,7 @@ public class UserSyncService {
                         "verified", false,
                         "deletedInIdp", true,
                         "action", "deleted_in_idp",
-                        "promotedToSuperAdmin", false
+                        "promotedToMostPrivilegedRole", false
                 ));
             }
         } catch (Exception e) {
@@ -183,7 +184,7 @@ public class UserSyncService {
                 metadata.put("totalUsersFromIdp", totalUsersFromIdp);
                 metadata.put("importedOrUpdatedCount", importedOrUpdatedCount);
                 metadata.put("deletedInIdpCount", deletedInIdpCount);
-                metadata.put("promotedToSuperAdminCount", promotedToSuperAdminCount);
+                metadata.put("promotedToMostPrivilegedRoleCount", promotedToMostPrivilegedRoleCount);
                 metadata.put("failureMessage", failureMessage != null ? failureMessage : "");
                 metadata.put("syncedUsers", syncedUsers);
 
@@ -192,11 +193,11 @@ public class UserSyncService {
                         .setTriggerType("UserSync")
                         .setMessage(success
                                 ? String.format(
-                                "Die Benutzersynchronisierung wurde erfolgreich abgeschlossen: %d von %d Benutzer:innen importiert oder aktualisiert, %d als im IdP gelöscht markiert, %d zu Super-Admin befördert.",
+                                "Die Benutzersynchronisierung wurde erfolgreich abgeschlossen: %d von %d Benutzer:innen importiert oder aktualisiert, %d als im IdP gelöscht markiert, %d zur Systemrolle mit höchster Berechtigungsstufe befördert.",
                                 importedOrUpdatedCount,
                                 totalUsersFromIdp,
                                 deletedInIdpCount,
-                                promotedToSuperAdminCount
+                                promotedToMostPrivilegedRoleCount
                         )
                                 : String.format(
                                 "Die Benutzersynchronisierung ist fehlgeschlagen: %s",

--- a/backend/src/main/java/de/aivot/gover/backend/userRoles/configs/MostPrivilegedSystemRoleSystemConfigDefinition.java
+++ b/backend/src/main/java/de/aivot/gover/backend/userRoles/configs/MostPrivilegedSystemRoleSystemConfigDefinition.java
@@ -1,0 +1,88 @@
+package de.aivot.gover.backend.userRoles.configs;
+
+import de.aivot.gover.backend.config.models.SystemConfigDefinition;
+import de.aivot.gover.backend.elements.models.elements.BaseElement;
+import de.aivot.gover.backend.elements.models.elements.form.input.SelectInputElement;
+import de.aivot.gover.backend.elements.models.elements.form.input.SelectInputElementOption;
+import de.aivot.gover.backend.lib.exceptions.ResponseException;
+import de.aivot.gover.backend.userRoles.repositories.SystemRoleRepository;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MostPrivilegedSystemRoleSystemConfigDefinition implements SystemConfigDefinition<String> {
+    public static final String KEY = "system_roles.most_privileged_role";
+    public static final Integer DEFAULT_SYSTEM_ROLE_ID = 1;
+
+    private final SystemRoleRepository systemRoleRepository;
+
+    @Autowired
+    public MostPrivilegedSystemRoleSystemConfigDefinition(SystemRoleRepository systemRoleRepository) {
+        this.systemRoleRepository = systemRoleRepository;
+    }
+
+    @Nonnull
+    @Override
+    public String getKey() {
+        return KEY;
+    }
+
+    @Nonnull
+    @Override
+    public BaseElement getConfigElement() {
+        return new SelectInputElement()
+                .setOptions(
+                        systemRoleRepository
+                                .findAll()
+                                .stream()
+                                .map(role -> SelectInputElementOption.of(role.getId().toString(), role.getName()))
+                                .toList()
+                )
+                .setLabel(getLabel())
+                .setHint(getDescription())
+                .setId(getKey());
+    }
+
+    @Nonnull
+    @Override
+    public String getCategory() {
+        return "Systemrollen";
+    }
+
+    @Nonnull
+    @Override
+    public String getLabel() {
+        return "Systemrolle mit höchster Berechtigungsstufe";
+    }
+
+    @Nonnull
+    @Override
+    public String getDescription() {
+        return "Diese Systemrolle gilt in Gover als höchste Berechtigungsstufe. Besitzt keine aktive Mitarbeiter:in diese Rolle, wird sie automatisch dem Administrationskonto zugewiesen, dessen E-Mail-Adresse über die Umgebungsvariable GOVER_BOOTSTRAP_ADMIN_MAIL konfiguriert ist.";
+    }
+
+    @Override
+    public String getDefaultValue() {
+        return DEFAULT_SYSTEM_ROLE_ID.toString();
+    }
+
+    @Nullable
+    @Override
+    public String parseValueFromDB(@Nonnull String value) throws ResponseException {
+        try {
+            Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            throw ResponseException.internalServerError("Ungültiger Wert für " + getKey() + ": " + value);
+        }
+        return value;
+    }
+
+    @Override
+    public void validate(@Nullable String value) throws ResponseException {
+        if (value == null || !systemRoleRepository.existsById(Integer.parseInt(value))) {
+            throw ResponseException.badRequest("Die ausgewählte Systemrolle existiert nicht.");
+        }
+    }
+}

--- a/backend/src/main/java/de/aivot/gover/backend/userRoles/controllers/SystemRoleController.java
+++ b/backend/src/main/java/de/aivot/gover/backend/userRoles/controllers/SystemRoleController.java
@@ -235,12 +235,19 @@ public class SystemRoleController {
                 "defaultSystemRoleForAutomaticImportsUpdated",
                 deleteResult.defaultSystemRoleForAutomaticImportsUpdated()
         );
+        auditMetadata.put(
+                "mostPrivilegedSystemRoleUpdated",
+                deleteResult.mostPrivilegedSystemRoleUpdated()
+        );
         if (deleteResult.replacementRole() != null) {
             auditMetadata.put("replacementRoleId", deleteResult.replacementRole().getId());
             auditMetadata.put("replacementRoleName", deleteResult.replacementRole().getName());
         }
         if (deleteResult.newDefaultSystemRoleId() != null) {
             auditMetadata.put("newDefaultSystemRoleId", deleteResult.newDefaultSystemRoleId());
+        }
+        if (deleteResult.newMostPrivilegedSystemRoleId() != null) {
+            auditMetadata.put("newMostPrivilegedSystemRoleId", deleteResult.newMostPrivilegedSystemRoleId());
         }
 
         var auditMessage = new StringBuilder(String.format(
@@ -262,6 +269,12 @@ public class SystemRoleController {
                     StringUtils.quote(deleteResult.replacementRole().getName())
             ));
         }
+        if (deleteResult.mostPrivilegedSystemRoleUpdated() && deleteResult.replacementRole() != null) {
+            auditMessage.append(String.format(
+                    " Die Systemrolle mit der höchsten Berechtigungsstufe wurde auf %s gesetzt.",
+                    StringUtils.quote(deleteResult.replacementRole().getName())
+            ));
+        }
 
         auditService
                 .create()
@@ -278,7 +291,9 @@ public class SystemRoleController {
         return new DeleteSystemRoleResponseDto(
                 deleteResult.migratedUsersCount(),
                 deleteResult.defaultSystemRoleForAutomaticImportsUpdated(),
-                deleteResult.newDefaultSystemRoleId()
+                deleteResult.newDefaultSystemRoleId(),
+                deleteResult.mostPrivilegedSystemRoleUpdated(),
+                deleteResult.newMostPrivilegedSystemRoleId()
         );
     }
 }

--- a/backend/src/main/java/de/aivot/gover/backend/userRoles/dtos/DeleteSystemRoleResponseDto.java
+++ b/backend/src/main/java/de/aivot/gover/backend/userRoles/dtos/DeleteSystemRoleResponseDto.java
@@ -5,6 +5,8 @@ import jakarta.annotation.Nullable;
 public record DeleteSystemRoleResponseDto(
         int migratedUsersCount,
         boolean defaultSystemRoleForAutomaticImportsUpdated,
-        @Nullable Integer newDefaultSystemRoleId
+        @Nullable Integer newDefaultSystemRoleId,
+        boolean mostPrivilegedSystemRoleUpdated,
+        @Nullable Integer newMostPrivilegedSystemRoleId
 ) {
 }

--- a/backend/src/main/java/de/aivot/gover/backend/userRoles/repositories/SystemRoleRepository.java
+++ b/backend/src/main/java/de/aivot/gover/backend/userRoles/repositories/SystemRoleRepository.java
@@ -3,22 +3,8 @@ package de.aivot.gover.backend.userRoles.repositories;
 import de.aivot.gover.backend.userRoles.entities.SystemRoleEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 public interface SystemRoleRepository extends JpaRepository<SystemRoleEntity, Integer>, JpaSpecificationExecutor<SystemRoleEntity> {
-    @Query(
-            value = """
-                    SELECT * FROM system_roles
-                    WHERE array_length(permissions, 1) = (
-                        SELECT MAX(array_length(permissions, 1)) FROM system_roles
-                    )
-                    """,
-            nativeQuery = true
-    )
-    Optional<SystemRoleEntity> findByMaxPermissions();
 }
-

--- a/backend/src/main/java/de/aivot/gover/backend/userRoles/services/SystemRoleService.java
+++ b/backend/src/main/java/de/aivot/gover/backend/userRoles/services/SystemRoleService.java
@@ -7,6 +7,7 @@ import de.aivot.gover.backend.lib.services.EntityService;
 import de.aivot.gover.backend.permissions.models.PermissionProvider;
 import de.aivot.gover.backend.user.configs.DefaultUserSystemRoleSystemConfigDefinition;
 import de.aivot.gover.backend.user.repositories.UserRepository;
+import de.aivot.gover.backend.userRoles.configs.MostPrivilegedSystemRoleSystemConfigDefinition;
 import de.aivot.gover.backend.userRoles.entities.SystemRoleEntity;
 import de.aivot.gover.backend.userRoles.repositories.SystemRoleRepository;
 import jakarta.annotation.Nonnull;
@@ -49,7 +50,9 @@ public class SystemRoleService implements EntityService<SystemRoleEntity, Intege
             int migratedUsersCount,
             @Nonnull List<MigratedUserAuditInfo> migratedUsers,
             boolean defaultSystemRoleForAutomaticImportsUpdated,
-            @Nullable Integer newDefaultSystemRoleId
+            @Nullable Integer newDefaultSystemRoleId,
+            boolean mostPrivilegedSystemRoleUpdated,
+            @Nullable Integer newMostPrivilegedSystemRoleId
     ) {
     }
 
@@ -95,9 +98,20 @@ public class SystemRoleService implements EntityService<SystemRoleEntity, Intege
                         "Die konfigurierte Standard-Systemrolle für automatische Benutzerimporte ist ungültig."
                 ));
 
+        var mostPrivilegedSystemRoleConfig = systemConfigService
+                .retrieve(MostPrivilegedSystemRoleSystemConfigDefinition.KEY);
+        var mostPrivilegedSystemRoleId = mostPrivilegedSystemRoleConfig
+                .getValueAsInteger()
+                .orElseThrow(() -> ResponseException.internalServerError(
+                        "Die konfigurierte Systemrolle mit der höchsten Berechtigungsstufe ist ungültig."
+                ));
+
         var affectsDefaultSystemRoleForAutomaticImports = roleToDeleteId.equals(defaultSystemRoleId);
+        var affectsMostPrivilegedSystemRole = roleToDeleteId.equals(mostPrivilegedSystemRoleId);
         var hasAssignedUsers = Boolean.TRUE.equals(userRepository.existsBySystemRoleId(roleToDeleteId));
-        var replacementRoleRequired = affectsDefaultSystemRoleForAutomaticImports || hasAssignedUsers;
+        var replacementRoleRequired = affectsDefaultSystemRoleForAutomaticImports ||
+                                      affectsMostPrivilegedSystemRole ||
+                                      hasAssignedUsers;
 
         if (replacementSystemRoleId != null && roleToDeleteId.equals(replacementSystemRoleId)) {
             throw ResponseException.badRequest("Bitte wählen Sie eine andere Systemrolle als Ersatz aus.");
@@ -141,6 +155,18 @@ public class SystemRoleService implements EntityService<SystemRoleEntity, Intege
             newDefaultSystemRoleId = replacementRole.getId();
         }
 
+        var mostPrivilegedSystemRoleUpdated = false;
+        Integer newMostPrivilegedSystemRoleId = null;
+        if (affectsMostPrivilegedSystemRole && replacementRole != null) {
+            mostPrivilegedSystemRoleConfig.setValue(String.valueOf(replacementRole.getId()));
+            systemConfigService.save(
+                    MostPrivilegedSystemRoleSystemConfigDefinition.KEY,
+                    mostPrivilegedSystemRoleConfig
+            );
+            mostPrivilegedSystemRoleUpdated = true;
+            newMostPrivilegedSystemRoleId = replacementRole.getId();
+        }
+
         repository.delete(roleToDelete);
 
         return new DeleteSystemRoleResult(
@@ -148,7 +174,9 @@ public class SystemRoleService implements EntityService<SystemRoleEntity, Intege
                 migratedUsersCount,
                 migratedUsers,
                 defaultSystemRoleForAutomaticImportsUpdated,
-                newDefaultSystemRoleId
+                newDefaultSystemRoleId,
+                mostPrivilegedSystemRoleUpdated,
+                newMostPrivilegedSystemRoleId
         );
     }
 

--- a/backend/src/main/resources/db/migration/V17_1_0__default_system_roles.sql
+++ b/backend/src/main/resources/db/migration/V17_1_0__default_system_roles.sql
@@ -310,6 +310,13 @@ values ('users.default_system_role', '3')
 on conflict (key) do update
     set value = excluded.value;
 
+-- set the system role that represents the highest permission level
+insert into system_configs (key,
+                            value)
+values ('system_roles.most_privileged_role', '1')
+on conflict (key) do update
+    set value = excluded.value;
+
 -- fix id sequence for system_roles
 select setval('system_roles_id_seq',
               (select max(id) from system_roles));

--- a/backend/src/test/java/de/aivot/gover/backend/user/services/ImportedUserSystemRoleServiceTest.java
+++ b/backend/src/test/java/de/aivot/gover/backend/user/services/ImportedUserSystemRoleServiceTest.java
@@ -7,6 +7,7 @@ import de.aivot.gover.backend.models.config.GoverConfig;
 import de.aivot.gover.backend.user.configs.DefaultUserSystemRoleSystemConfigDefinition;
 import de.aivot.gover.backend.user.repositories.UserRepository;
 import de.aivot.gover.backend.user.services.ImportedUserSystemRoleService;
+import de.aivot.gover.backend.userRoles.configs.MostPrivilegedSystemRoleSystemConfigDefinition;
 import de.aivot.gover.backend.userRoles.repositories.SystemRoleRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -62,7 +63,62 @@ class ImportedUserSystemRoleServiceTest {
     }
 
     @Test
-    void resolveSystemRoleIdShouldPromoteBootstrapAdminIfNoSuperAdminExists() {
+    void getMostPrivilegedSystemRoleIdShouldReturnConfiguredRole() throws ResponseException {
+        var goverConfig = new GoverConfig();
+        var configService = mock(SystemConfigService.class);
+        var systemRoleRepository = mock(SystemRoleRepository.class);
+        var userRepository = mock(UserRepository.class);
+
+        when(configService.retrieve(MostPrivilegedSystemRoleSystemConfigDefinition.KEY))
+                .thenReturn(new SystemConfigEntity()
+                        .setKey(MostPrivilegedSystemRoleSystemConfigDefinition.KEY)
+                        .setValue("7")
+                        .setPublicConfig(false));
+        when(systemRoleRepository.existsById(7)).thenReturn(true);
+
+        var service = new ImportedUserSystemRoleService(goverConfig, configService, systemRoleRepository, userRepository);
+
+        assertEquals(7, service.getMostPrivilegedSystemRoleId());
+    }
+
+    @Test
+    void getMostPrivilegedSystemRoleIdShouldRejectUnknownConfiguredRole() throws ResponseException {
+        var goverConfig = new GoverConfig();
+        var configService = mock(SystemConfigService.class);
+        var systemRoleRepository = mock(SystemRoleRepository.class);
+        var userRepository = mock(UserRepository.class);
+
+        when(configService.retrieve(MostPrivilegedSystemRoleSystemConfigDefinition.KEY))
+                .thenReturn(new SystemConfigEntity()
+                        .setKey(MostPrivilegedSystemRoleSystemConfigDefinition.KEY)
+                        .setValue("999")
+                        .setPublicConfig(false));
+        when(systemRoleRepository.existsById(999)).thenReturn(false);
+
+        var service = new ImportedUserSystemRoleService(goverConfig, configService, systemRoleRepository, userRepository);
+
+        var exception = assertThrows(ResponseException.class, service::getMostPrivilegedSystemRoleId);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, exception.getStatus());
+        assertEquals("Die konfigurierte Systemrolle mit der höchsten Berechtigungsstufe existiert nicht.", exception.getTitle());
+    }
+
+    @Test
+    void hasActiveUserWithMostPrivilegedRoleShouldUseActiveUserLookup() {
+        var userRepository = mock(UserRepository.class);
+        when(userRepository.existsActiveUserBySystemRoleId(7)).thenReturn(true);
+        var service = new ImportedUserSystemRoleService(
+                new GoverConfig(),
+                mock(SystemConfigService.class),
+                mock(SystemRoleRepository.class),
+                userRepository
+        );
+
+        assertEquals(true, service.hasActiveUserWithMostPrivilegedRole(7));
+    }
+
+    @Test
+    void resolveSystemRoleIdShouldPromoteBootstrapAdminToConfiguredMostPrivilegedRole() {
         var goverConfig = new GoverConfig();
         goverConfig.setBootstrapAdminMail(List.of("admin@example.org"));
 
@@ -73,10 +129,28 @@ class ImportedUserSystemRoleServiceTest {
                 mock(UserRepository.class)
         );
 
-        var resolution = service.resolveSystemRoleId("admin@example.org", null, 3, 1, false);
+        var resolution = service.resolveSystemRoleId("admin@example.org", null, 3, 7, false);
 
-        assertEquals(1, resolution.systemRoleId());
-        assertEquals(true, resolution.promotedToSuperAdmin());
+        assertEquals(7, resolution.systemRoleId());
+        assertEquals(true, resolution.promotedToMostPrivilegedRole());
+    }
+
+    @Test
+    void resolveSystemRoleIdShouldRestoreConfiguredRoleAfterManualRoleChange() {
+        var goverConfig = new GoverConfig();
+        goverConfig.setBootstrapAdminMail(List.of("admin@example.org"));
+
+        var service = new ImportedUserSystemRoleService(
+                goverConfig,
+                mock(SystemConfigService.class),
+                mock(SystemRoleRepository.class),
+                mock(UserRepository.class)
+        );
+
+        var resolution = service.resolveSystemRoleId("admin@example.org", 4, 3, 7, false);
+
+        assertEquals(7, resolution.systemRoleId());
+        assertEquals(true, resolution.promotedToMostPrivilegedRole());
     }
 
     @Test
@@ -91,7 +165,7 @@ class ImportedUserSystemRoleServiceTest {
         var resolution = service.resolveSystemRoleId("staff@example.org", 7, 3, 1, true);
 
         assertEquals(7, resolution.systemRoleId());
-        assertFalse(resolution.promotedToSuperAdmin());
+        assertFalse(resolution.promotedToMostPrivilegedRole());
     }
 
     @Test
@@ -106,6 +180,6 @@ class ImportedUserSystemRoleServiceTest {
         var resolution = service.resolveSystemRoleId("staff@example.org", null, 3, 1, true);
 
         assertEquals(3, resolution.systemRoleId());
-        assertFalse(resolution.promotedToSuperAdmin());
+        assertFalse(resolution.promotedToMostPrivilegedRole());
     }
 }

--- a/backend/src/test/java/de/aivot/gover/backend/user/services/UserSyncServiceTest.java
+++ b/backend/src/test/java/de/aivot/gover/backend/user/services/UserSyncServiceTest.java
@@ -60,8 +60,8 @@ class UserSyncServiceTest {
                 .setEmailVerified(true);
 
         when(importedUserSystemRoleService.getDefaultSystemRoleId()).thenReturn(3);
-        when(importedUserSystemRoleService.getSuperAdminRoleId()).thenReturn(1);
-        when(importedUserSystemRoleService.hasSuperAdminUser(1)).thenReturn(true);
+        when(importedUserSystemRoleService.getMostPrivilegedSystemRoleId()).thenReturn(1);
+        when(importedUserSystemRoleService.hasActiveUserWithMostPrivilegedRole(1)).thenReturn(true);
         when(importedUserSystemRoleService.resolveSystemRoleId("user@example.org", null, 3, 1, true))
                 .thenReturn(new ImportedUserSystemRoleService.ImportedUserSystemRoleResolution(3, false));
 

--- a/backend/src/test/java/de/aivot/gover/backend/userRoles/configs/MostPrivilegedSystemRoleSystemConfigDefinitionTest.java
+++ b/backend/src/test/java/de/aivot/gover/backend/userRoles/configs/MostPrivilegedSystemRoleSystemConfigDefinitionTest.java
@@ -1,0 +1,78 @@
+package de.aivot.gover.backend.userRoles.configs;
+
+import de.aivot.gover.backend.elements.models.elements.form.input.SelectInputElement;
+import de.aivot.gover.backend.elements.models.elements.form.input.SelectInputElementOption;
+import de.aivot.gover.backend.lib.exceptions.ResponseException;
+import de.aivot.gover.backend.userRoles.entities.SystemRoleEntity;
+import de.aivot.gover.backend.userRoles.repositories.SystemRoleRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MostPrivilegedSystemRoleSystemConfigDefinitionTest {
+    @Test
+    void getDefaultValueShouldReturnSuperAdministratorSystemRoleId() {
+        var definition = new MostPrivilegedSystemRoleSystemConfigDefinition(mock(SystemRoleRepository.class));
+
+        assertEquals("1", definition.getDefaultValue());
+    }
+
+    @Test
+    void getConfigElementShouldReturnSystemRoleOptions() {
+        var repository = mock(SystemRoleRepository.class);
+        when(repository.findAll()).thenReturn(List.of(
+                new SystemRoleEntity().setId(1).setName("Superadministrator:in"),
+                new SystemRoleEntity().setId(4).setName("Sachbearbeiter:in")
+        ));
+
+        var definition = new MostPrivilegedSystemRoleSystemConfigDefinition(repository);
+
+        var element = assertInstanceOf(SelectInputElement.class, definition.getConfigElement());
+        assertEquals(MostPrivilegedSystemRoleSystemConfigDefinition.KEY, element.getId());
+        assertEquals(definition.getLabel(), element.getLabel());
+        assertEquals(definition.getDescription(), element.getHint());
+        assertEquals(List.of(
+                SelectInputElementOption.of("1", "Superadministrator:in"),
+                SelectInputElementOption.of("4", "Sachbearbeiter:in")
+        ), element.getOptions());
+    }
+
+    @Test
+    void parseValueFromDBShouldRejectNonNumericValue() {
+        var definition = new MostPrivilegedSystemRoleSystemConfigDefinition(mock(SystemRoleRepository.class));
+
+        var exception = assertThrows(ResponseException.class, () -> definition.parseValueFromDB("not-a-role-id"));
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, exception.getStatus());
+        assertEquals("Ungültiger Wert für system_roles.most_privileged_role: not-a-role-id", exception.getTitle());
+    }
+
+    @Test
+    void validateShouldAcceptExistingSystemRole() {
+        var repository = mock(SystemRoleRepository.class);
+        when(repository.existsById(1)).thenReturn(true);
+        var definition = new MostPrivilegedSystemRoleSystemConfigDefinition(repository);
+
+        assertDoesNotThrow(() -> definition.validate("1"));
+    }
+
+    @Test
+    void validateShouldRejectUnknownSystemRole() {
+        var repository = mock(SystemRoleRepository.class);
+        when(repository.existsById(999)).thenReturn(false);
+        var definition = new MostPrivilegedSystemRoleSystemConfigDefinition(repository);
+
+        var exception = assertThrows(ResponseException.class, () -> definition.validate("999"));
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus());
+        assertEquals("Die ausgewählte Systemrolle existiert nicht.", exception.getTitle());
+    }
+}

--- a/backend/src/test/java/de/aivot/gover/backend/userRoles/services/SystemRoleServiceTest.java
+++ b/backend/src/test/java/de/aivot/gover/backend/userRoles/services/SystemRoleServiceTest.java
@@ -8,6 +8,7 @@ import de.aivot.gover.backend.permissions.permissions.PermissionSetPermissionPro
 import de.aivot.gover.backend.user.configs.DefaultUserSystemRoleSystemConfigDefinition;
 import de.aivot.gover.backend.user.entities.UserEntity;
 import de.aivot.gover.backend.user.repositories.UserRepository;
+import de.aivot.gover.backend.userRoles.configs.MostPrivilegedSystemRoleSystemConfigDefinition;
 import de.aivot.gover.backend.userRoles.entities.SystemRoleEntity;
 import de.aivot.gover.backend.userRoles.repositories.SystemRoleRepository;
 import org.junit.jupiter.api.Test;
@@ -36,17 +37,28 @@ class SystemRoleServiceTest {
         ));
     }
 
+    private static void mockConfiguredSystemRoles(SystemConfigService systemConfigService,
+                                                  int defaultSystemRoleId,
+                                                  int mostPrivilegedSystemRoleId) throws ResponseException {
+        when(systemConfigService.retrieve(DefaultUserSystemRoleSystemConfigDefinition.KEY))
+                .thenReturn(new SystemConfigEntity()
+                        .setKey(DefaultUserSystemRoleSystemConfigDefinition.KEY)
+                        .setValue(String.valueOf(defaultSystemRoleId))
+                        .setPublicConfig(false));
+        when(systemConfigService.retrieve(MostPrivilegedSystemRoleSystemConfigDefinition.KEY))
+                .thenReturn(new SystemConfigEntity()
+                        .setKey(MostPrivilegedSystemRoleSystemConfigDefinition.KEY)
+                        .setValue(String.valueOf(mostPrivilegedSystemRoleId))
+                        .setPublicConfig(false));
+    }
+
     @Test
     void performDeleteShouldRejectDeletingRoleWithAssignedUsersWithoutReplacement() throws ResponseException {
         var repository = mock(SystemRoleRepository.class);
         var systemConfigService = mock(SystemConfigService.class);
         var userRepository = mock(UserRepository.class);
 
-        when(systemConfigService.retrieve(DefaultUserSystemRoleSystemConfigDefinition.KEY))
-                .thenReturn(new SystemConfigEntity()
-                        .setKey(DefaultUserSystemRoleSystemConfigDefinition.KEY)
-                        .setValue("3")
-                        .setPublicConfig(false));
+        mockConfiguredSystemRoles(systemConfigService, 3, 1);
         when(userRepository.existsBySystemRoleId(4)).thenReturn(true);
 
         var service = createService(repository, systemConfigService, userRepository);
@@ -71,11 +83,7 @@ class SystemRoleServiceTest {
         var systemConfigService = mock(SystemConfigService.class);
         var userRepository = mock(UserRepository.class);
 
-        when(systemConfigService.retrieve(DefaultUserSystemRoleSystemConfigDefinition.KEY))
-                .thenReturn(new SystemConfigEntity()
-                        .setKey(DefaultUserSystemRoleSystemConfigDefinition.KEY)
-                        .setValue("3")
-                        .setPublicConfig(false));
+        mockConfiguredSystemRoles(systemConfigService, 3, 1);
         when(userRepository.existsBySystemRoleId(4)).thenReturn(false);
         when(userRepository.findAllBySystemRoleIdOrderByFullNameAsc(4)).thenReturn(List.of());
 
@@ -92,8 +100,10 @@ class SystemRoleServiceTest {
         verify(systemConfigService, never()).save(eq(DefaultUserSystemRoleSystemConfigDefinition.KEY), any());
         assertEquals(0, result.migratedUsersCount());
         assertEquals(false, result.defaultSystemRoleForAutomaticImportsUpdated());
+        assertEquals(false, result.mostPrivilegedSystemRoleUpdated());
         assertNull(result.replacementRole());
         assertNull(result.newDefaultSystemRoleId());
+        assertNull(result.newMostPrivilegedSystemRoleId());
         assertEquals(List.of(), result.migratedUsers());
     }
 
@@ -110,6 +120,11 @@ class SystemRoleServiceTest {
 
         when(systemConfigService.retrieve(DefaultUserSystemRoleSystemConfigDefinition.KEY))
                 .thenReturn(defaultSystemRoleConfig);
+        when(systemConfigService.retrieve(MostPrivilegedSystemRoleSystemConfigDefinition.KEY))
+                .thenReturn(new SystemConfigEntity()
+                        .setKey(MostPrivilegedSystemRoleSystemConfigDefinition.KEY)
+                        .setValue("1")
+                        .setPublicConfig(false));
         when(userRepository.existsBySystemRoleId(3)).thenReturn(true);
         when(userRepository.findAllBySystemRoleIdOrderByFullNameAsc(3)).thenReturn(List.of(
                 new UserEntity()
@@ -142,12 +157,102 @@ class SystemRoleServiceTest {
         verify(repository).delete(entity);
         assertEquals(5, result.migratedUsersCount());
         assertEquals(true, result.defaultSystemRoleForAutomaticImportsUpdated());
+        assertEquals(false, result.mostPrivilegedSystemRoleUpdated());
         assertEquals(7, result.replacementRole().getId());
         assertEquals(7, result.newDefaultSystemRoleId());
+        assertNull(result.newMostPrivilegedSystemRoleId());
         assertEquals(2, result.migratedUsers().size());
         assertEquals("user-1", result.migratedUsers().get(0).id());
         assertEquals("Erika Musterfrau", result.migratedUsers().get(0).fullName());
         assertEquals("erika.musterfrau@example.org", result.migratedUsers().get(0).email());
+    }
+
+    @Test
+    void deleteAndMigrateUsersShouldUpdateMostPrivilegedSystemRoleWhenDeletingConfiguredRole() throws ResponseException {
+        var repository = mock(SystemRoleRepository.class);
+        var systemConfigService = mock(SystemConfigService.class);
+        var userRepository = mock(UserRepository.class);
+
+        var mostPrivilegedSystemRoleConfig = new SystemConfigEntity()
+                .setKey(MostPrivilegedSystemRoleSystemConfigDefinition.KEY)
+                .setValue("1")
+                .setPublicConfig(false);
+        when(systemConfigService.retrieve(DefaultUserSystemRoleSystemConfigDefinition.KEY))
+                .thenReturn(new SystemConfigEntity()
+                        .setKey(DefaultUserSystemRoleSystemConfigDefinition.KEY)
+                        .setValue("3")
+                        .setPublicConfig(false));
+        when(systemConfigService.retrieve(MostPrivilegedSystemRoleSystemConfigDefinition.KEY))
+                .thenReturn(mostPrivilegedSystemRoleConfig);
+        when(userRepository.existsBySystemRoleId(1)).thenReturn(false);
+
+        var replacementRole = new SystemRoleEntity()
+                .setId(7)
+                .setName("Notfalladministration")
+                .setPermissions(List.of());
+        when(repository.findById(7)).thenReturn(Optional.of(replacementRole));
+
+        var service = createService(repository, systemConfigService, userRepository);
+        var entity = new SystemRoleEntity()
+                .setId(1)
+                .setName("Superadministrator:in")
+                .setPermissions(List.of());
+
+        var result = service.deleteAndMigrateUsers(entity, 7);
+
+        verify(systemConfigService).save(
+                MostPrivilegedSystemRoleSystemConfigDefinition.KEY,
+                mostPrivilegedSystemRoleConfig
+        );
+        verify(repository).delete(entity);
+        assertEquals(false, result.defaultSystemRoleForAutomaticImportsUpdated());
+        assertEquals(true, result.mostPrivilegedSystemRoleUpdated());
+        assertEquals(7, result.newMostPrivilegedSystemRoleId());
+    }
+
+    @Test
+    void deleteAndMigrateUsersShouldUpdateBothRoleConfigsWhenTheyReferenceDeletedRole() throws ResponseException {
+        var repository = mock(SystemRoleRepository.class);
+        var systemConfigService = mock(SystemConfigService.class);
+        var userRepository = mock(UserRepository.class);
+
+        var defaultSystemRoleConfig = new SystemConfigEntity()
+                .setKey(DefaultUserSystemRoleSystemConfigDefinition.KEY)
+                .setValue("3")
+                .setPublicConfig(false);
+        var mostPrivilegedSystemRoleConfig = new SystemConfigEntity()
+                .setKey(MostPrivilegedSystemRoleSystemConfigDefinition.KEY)
+                .setValue("3")
+                .setPublicConfig(false);
+        when(systemConfigService.retrieve(DefaultUserSystemRoleSystemConfigDefinition.KEY))
+                .thenReturn(defaultSystemRoleConfig);
+        when(systemConfigService.retrieve(MostPrivilegedSystemRoleSystemConfigDefinition.KEY))
+                .thenReturn(mostPrivilegedSystemRoleConfig);
+        when(userRepository.existsBySystemRoleId(3)).thenReturn(false);
+
+        var replacementRole = new SystemRoleEntity()
+                .setId(7)
+                .setName("Ersatzrolle")
+                .setPermissions(List.of());
+        when(repository.findById(7)).thenReturn(Optional.of(replacementRole));
+
+        var service = createService(repository, systemConfigService, userRepository);
+        var entity = new SystemRoleEntity()
+                .setId(3)
+                .setName("Gemeinsame Systemrolle")
+                .setPermissions(List.of());
+
+        var result = service.deleteAndMigrateUsers(entity, 7);
+
+        verify(systemConfigService).save(DefaultUserSystemRoleSystemConfigDefinition.KEY, defaultSystemRoleConfig);
+        verify(systemConfigService).save(
+                MostPrivilegedSystemRoleSystemConfigDefinition.KEY,
+                mostPrivilegedSystemRoleConfig
+        );
+        assertEquals(true, result.defaultSystemRoleForAutomaticImportsUpdated());
+        assertEquals(true, result.mostPrivilegedSystemRoleUpdated());
+        assertEquals(7, result.newDefaultSystemRoleId());
+        assertEquals(7, result.newMostPrivilegedSystemRoleId());
     }
 
     @Test

--- a/development/README.md
+++ b/development/README.md
@@ -254,18 +254,19 @@ Make sure to save the new password and the OTP secret in a secure place, as you 
 - Gover authenticates its own users against the Keycloak realm configured by `GOVER_KEYCLOAK_OIDC_REALM`.
 - In the default development setup, `GOVER_KEYCLOAK_OIDC_REALM` is set to `staff`.
 - Because of this, only users from the `staff` realm can log into the Gover staff app directly and be imported as Gover users.
-- The Gover bootstrap super admin is therefore a Gover application user from the `staff` realm, not a special Keycloak admin-console account.
+- The Gover bootstrap administrator is therefore a Gover application user from the `staff` realm, not a special Keycloak admin-console account.
 - The `customer` realm is used for customer identity provider integration and is not used for direct Gover staff login.
-- A user is promoted to the Gover system role `Superadministrator:in` only when all of the following are true:
+- A user is promoted to the configured Gover system role with the highest permission level only when all of the following are true:
   - the user is imported into Gover by user synchronization or by logging into Gover
   - the user comes from the `staff` realm
   - the user's e-mail address matches `GOVER_BOOTSTRAP_ADMIN_MAIL`
-  - no Gover super admin exists yet
+  - no active Gover user holds that system role
+- The role with the highest permission level defaults to `Superadministrator:in` and can be changed under the general application settings.
 - In the default development setup, these values are different:
   - the Keycloak admin user `superuser` has the e-mail `mail@example.com`
   - `GOVER_BOOTSTRAP_ADMIN_MAIL` in `./development/gover.env` is set to `admin@example.com`
 
-Because of this, the default Keycloak user `superuser` does not become the bootstrap Gover super admin.
+Because of this, the default Keycloak user `superuser` does not become the bootstrap Gover administrator.
 
 The Keycloak Setup Helper creates the following realms:
 
@@ -281,14 +282,14 @@ After saving the user, go to the "Credentials" tab and set a password for the us
 Make sure to disable the "Temporary" option, so the password does not expire after the first login.
 The user is now available for logging into the staff frontend application.
 
-If this staff user should become the first Gover super admin, set the user's e-mail address to the value of `GOVER_BOOTSTRAP_ADMIN_MAIL` before the user logs into Gover for the first time.
+If this staff user should receive Gover's system role with the highest permission level, set the user's e-mail address to the value of `GOVER_BOOTSTRAP_ADMIN_MAIL` before the user logs into Gover for the first time.
 In the default development setup, that means using the e-mail address `admin@example.com`, or changing `GOVER_BOOTSTRAP_ADMIN_MAIL` in `./development/gover.env` before the first import/login.
 
 **Bootstrap Gover Admin User:**
 
-When Keycloak users are synced into Gover, or when a user logs into Gover and is imported on demand, Gover checks whether that user should become the bootstrap super admin.
+When Keycloak users are synced into Gover, or when a user logs into Gover and is imported on demand, Gover checks whether that user should receive the system role with the highest permission level.
 Gover does this by comparing the imported user's e-mail address with the environment variable `GOVER_BOOTSTRAP_ADMIN_MAIL` in `./development/gover.env`.
-If the e-mail address matches and no Gover super admin exists yet, that user receives the Gover system role `Superadministrator:in`, which grants full access to the Gover application.
+If the e-mail address matches and no active Gover user holds the configured role, that user receives it. The role defaults to `Superadministrator:in`.
 
 ### 3.6 Message Broker (RabbitMQ)
 

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -110,7 +110,8 @@ To create the initial Gover administrator:
 7. Log into `${GOVER_HOSTNAME}/staff` with that staff user.
 
 When this user logs into Gover for the first time, Gover imports the user.
-If no Gover super administrator exists yet and the e-mail address matches `GOVER_BOOTSTRAP_ADMIN_MAIL`, the user receives the `Superadministrator:in` system role.
+If no active Gover user holds the configured system role with the highest permission level and the e-mail address matches `GOVER_BOOTSTRAP_ADMIN_MAIL`, the user receives that role.
+The role defaults to `Superadministrator:in` and can later be changed under the general application settings.
 
 ## 6. Backups
 


### PR DESCRIPTION
This PR introduces an explicit system configuration for the system role that represents Gover's highest permission level.

Previously, the bootstrap administrator process selected the role with the largest number of permission keys. This could incorrectly treat a broad operational role as more privileged than an explicitly defined super-administrator role.

## Changes

- Add the `system_roles.most_privileged_role` system configuration.
- Default the configuration to system role `1` (`Superadministrator:in`).
- Replace permission-count-based role selection with the configured role ID.
- Consider only enabled users that have not been deleted in the identity provider when checking whether the role is currently held.
- Keep the existing unrestricted role-assignment lookup for deletion and migration workflows.
- Add the new selection field to the application settings.
- Mark the configured role in the system role list and details page.
- Migrate the configuration when its referenced role is deleted.
- Extend deletion responses, audit metadata and user-sync audit messages.
- Update bootstrap administrator documentation.
- Add regression tests for configuration validation, role restoration and role deletion.

OP#915