### PR TITLE
fix(xrepository): ignore unknown genericode metadata

### DIFF
--- a/backend/src/main/java/de/aivot/gover/backend/xrepository/services/XRepositoryCodeListService.java
+++ b/backend/src/main/java/de/aivot/gover/backend/xrepository/services/XRepositoryCodeListService.java
@@ -1,6 +1,7 @@
 package de.aivot.gover.backend.xrepository.services;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import de.aivot.gover.backend.core.exceptions.HttpConnectionException;
 import de.aivot.gover.backend.core.services.HttpService;
@@ -23,6 +24,9 @@ import java.util.Map;
 @Service
 public class XRepositoryCodeListService {
     private static final String XREPOSITORY_API_URL = "https://www.xrepository.de/api/xrepository/";
+    private static final XmlMapper XML_MAPPER = XmlMapper.builder()
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .build();
     private final HttpService httpService;
 
     public XRepositoryCodeListService(HttpService httpService) {
@@ -47,8 +51,7 @@ public class XRepositoryCodeListService {
         switch (response.statusCode()) {
             case 200:
                 try {
-                    return new XmlMapper()
-                            .readValue(response.body(), XRepositoryCodeList.class);
+                    return XML_MAPPER.readValue(response.body(), XRepositoryCodeList.class);
                 } catch (JsonProcessingException e) {
                     throw ResponseException.internalServerError(e, "Fehler beim Parsen der Codeliste mit der URN %s: %s", codeListUrn, e.getMessage());
                 }

--- a/backend/src/test/java/de/aivot/gover/backend/xrepository/services/XRepositoryCodeListServiceTest.java
+++ b/backend/src/test/java/de/aivot/gover/backend/xrepository/services/XRepositoryCodeListServiceTest.java
@@ -1,0 +1,59 @@
+package de.aivot.gover.backend.xrepository.services;
+
+import de.aivot.gover.backend.core.services.HttpService;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class XRepositoryCodeListServiceTest {
+    @Test
+    void parsesCodeListWithAdditionalGenericodeMetadata() throws Exception {
+        var xml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <gc:CodeList xmlns:gc="http://docs.oasis-open.org/codelist/ns/genericode/1.0/"
+                             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                             xsi:schemaLocation="http://docs.oasis-open.org/codelist/ns/genericode/1.0/ genericode.xsd">
+                    <Identification>
+                        <ShortName>Test</ShortName>
+                        <AlternateFormatLocationUri>https://example.com/test</AlternateFormatLocationUri>
+                    </Identification>
+                    <ColumnSet>
+                        <Column Id="code" Use="required">
+                            <ShortName>Code</ShortName>
+                            <LongName xml:lang="de-DE">Code</LongName>
+                            <Data Type="string"/>
+                        </Column>
+                        <Key Id="code-key">
+                            <ShortName>Code</ShortName>
+                            <ColumnRef Ref="code"/>
+                        </Key>
+                    </ColumnSet>
+                    <SimpleCodeList>
+                        <Row>
+                            <Value ColumnRef="code">
+                                <SimpleValue>001</SimpleValue>
+                            </Value>
+                        </Row>
+                    </SimpleCodeList>
+                </gc:CodeList>
+                """;
+        var httpService = mock(HttpService.class);
+        @SuppressWarnings("unchecked")
+        HttpResponse<String> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(200);
+        when(response.body()).thenReturn(xml);
+        when(httpService.get(any(URI.class))).thenReturn(response);
+
+        var codeList = new XRepositoryCodeListService(httpService).getCodeList("urn:test");
+
+        assertEquals("Test", codeList.getIdentification().getShortName());
+        assertEquals("code", codeList.getColumnSet().getColumn().getFirst().getId());
+        assertEquals("001", codeList.getCodeList().getRow().getFirst().getValue().getFirst().getSimpleValue());
+    }
+}


### PR DESCRIPTION
## Summary

- configure the XRepository XML mapper to ignore unknown Genericode properties
- support code lists containing metadata such as `xsi:schemaLocation`
- add regression coverage for root-level and nested metadata
- preserve parsing of the required identification, column, and row data

## Context

The XRepository code list
`urn:de:bund:destatis:bevoelkerungsstatistik:schluessel:staatsangehoerigkeit_2024-08-01`

could not be parsed because its root element contains `xsi:schemaLocation`.
The XRepository models intentionally represent only the data required by Gover,
so additional valid Genericode metadata should not cause deserialization to fail.

OP#995