### PR TITLE
fix: restore saving of application settings

### DIFF
--- a/backend/src/main/java/de/aivot/gover/backend/config/controllers/SystemConfigController.java
+++ b/backend/src/main/java/de/aivot/gover/backend/config/controllers/SystemConfigController.java
@@ -128,7 +128,7 @@ public class SystemConfigController {
                 .orElseThrow(() -> ResponseException.notFound("Für den Schlüssel \"" + key + "\" wurde keine Systemkonfiguration gefunden."));
 
         var entity = updateRequest
-                .toEntity(def);
+                .toEntity();
 
         var config = systemConfigService
                 .save(key, entity, Boolean.TRUE.equals(updateRequest.changeConfirmed()));

--- a/backend/src/main/java/de/aivot/gover/backend/config/dtos/SystemConfigRequestDto.java
+++ b/backend/src/main/java/de/aivot/gover/backend/config/dtos/SystemConfigRequestDto.java
@@ -1,22 +1,23 @@
 package de.aivot.gover.backend.config.dtos;
 
 import de.aivot.gover.backend.config.entities.SystemConfigEntity;
-import de.aivot.gover.backend.config.models.SystemConfigDefinition;
-import de.aivot.gover.backend.lib.exceptions.ResponseException;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
 
 public record SystemConfigRequestDto(
-        @Nullable
-        Object value,
+        @Nonnull
+        @NotNull(message = "Der Wert darf nicht null sein.")
+        String value,
         @Nullable
         Boolean changeConfirmed
 ) {
     @Nonnull
-    public SystemConfigEntity toEntity(@Nonnull SystemConfigDefinition definition) throws ResponseException {
+    public SystemConfigEntity toEntity() {
         var entity = new SystemConfigEntity();
-        entity.setValue(definition.serializeValueToDB(value));
+        // Requests carry the persisted string format; SystemConfigService parses and validates it via the definition.
+        entity.setValue(value);
         return entity;
     }
 }

--- a/backend/src/main/java/de/aivot/gover/backend/core/configs/GlobalThemeSystemConfigDefinition.java
+++ b/backend/src/main/java/de/aivot/gover/backend/core/configs/GlobalThemeSystemConfigDefinition.java
@@ -69,6 +69,11 @@ public class GlobalThemeSystemConfigDefinition implements SystemConfigDefinition
     @Nullable
     @Override
     public String parseValueFromDB(@Nonnull String value) throws ResponseException {
+        // Optional references use an empty string to represent "not configured" in system_configs.
+        if (value.isEmpty()) {
+            return value;
+        }
+
         try {
             Integer.parseInt(value);
         } catch (NumberFormatException e) {

--- a/backend/src/main/java/de/aivot/gover/backend/core/configs/ListingPageAccesibilitySystemConfigDefinition.java
+++ b/backend/src/main/java/de/aivot/gover/backend/core/configs/ListingPageAccesibilitySystemConfigDefinition.java
@@ -69,6 +69,11 @@ public class ListingPageAccesibilitySystemConfigDefinition implements SystemConf
     @Nullable
     @Override
     public String parseValueFromDB(@Nonnull String value) throws ResponseException {
+        // Optional references use an empty string to represent "not configured" in system_configs.
+        if (value.isEmpty()) {
+            return value;
+        }
+
         try {
             Integer.parseInt(value);
         } catch (NumberFormatException e) {

--- a/backend/src/main/java/de/aivot/gover/backend/core/configs/ListingPageImprintSystemConfigDefinition.java
+++ b/backend/src/main/java/de/aivot/gover/backend/core/configs/ListingPageImprintSystemConfigDefinition.java
@@ -71,6 +71,11 @@ public class ListingPageImprintSystemConfigDefinition implements SystemConfigDef
     @Nullable
     @Override
     public String parseValueFromDB(@Nonnull String value) throws ResponseException {
+        // Optional references use an empty string to represent "not configured" in system_configs.
+        if (value.isEmpty()) {
+            return value;
+        }
+
         try {
             Integer.parseInt(value);
         } catch (NumberFormatException e) {

--- a/backend/src/main/java/de/aivot/gover/backend/core/configs/ListingPagePrivacySystemConfigDefinition.java
+++ b/backend/src/main/java/de/aivot/gover/backend/core/configs/ListingPagePrivacySystemConfigDefinition.java
@@ -68,6 +68,11 @@ public class ListingPagePrivacySystemConfigDefinition implements SystemConfigDef
     @Nullable
     @Override
     public String parseValueFromDB(@Nonnull String value) throws ResponseException {
+        // Optional references use an empty string to represent "not configured" in system_configs.
+        if (value.isEmpty()) {
+            return value;
+        }
+
         try {
             Integer.parseInt(value);
         } catch (NumberFormatException e) {

--- a/backend/src/test/java/de/aivot/gover/backend/config/dtos/SystemConfigRequestDtoTest.java
+++ b/backend/src/test/java/de/aivot/gover/backend/config/dtos/SystemConfigRequestDtoTest.java
@@ -1,0 +1,18 @@
+package de.aivot.gover.backend.config.dtos;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SystemConfigRequestDtoTest {
+    @ParameterizedTest
+    @ValueSource(strings = {"true", "false", ""})
+    void shouldPreserveSerializedValue(String value) {
+        var request = new SystemConfigRequestDto(value, null);
+
+        var entity = request.toEntity();
+
+        assertEquals(value, entity.getValue());
+    }
+}

--- a/backend/src/test/java/de/aivot/gover/backend/core/configs/OptionalReferenceSystemConfigDefinitionTest.java
+++ b/backend/src/test/java/de/aivot/gover/backend/core/configs/OptionalReferenceSystemConfigDefinitionTest.java
@@ -1,0 +1,86 @@
+package de.aivot.gover.backend.core.configs;
+
+import de.aivot.gover.backend.config.entities.SystemConfigEntity;
+import de.aivot.gover.backend.config.models.SystemConfigDefinition;
+import de.aivot.gover.backend.config.repositories.SystemConfigRepository;
+import de.aivot.gover.backend.config.services.SystemConfigService;
+import de.aivot.gover.backend.department.repositories.VDepartmentShadowedRepository;
+import de.aivot.gover.backend.lib.exceptions.ResponseException;
+import de.aivot.gover.backend.theme.repositories.ThemeRepository;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class OptionalReferenceSystemConfigDefinitionTest {
+    private static Stream<Named<SystemConfigDefinition<String>>> optionalReferenceDefinitions() {
+        var departmentRepository = mock(VDepartmentShadowedRepository.class);
+
+        return Stream.of(
+                Named.of("accessibility department", new ListingPageAccesibilitySystemConfigDefinition(departmentRepository)),
+                Named.of("imprint department", new ListingPageImprintSystemConfigDefinition(departmentRepository)),
+                Named.of("privacy department", new ListingPagePrivacySystemConfigDefinition(departmentRepository)),
+                Named.of("global theme", new GlobalThemeSystemConfigDefinition(mock(ThemeRepository.class)))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("optionalReferenceDefinitions")
+    void shouldPreserveEmptyValue(SystemConfigDefinition<String> definition) throws ResponseException {
+        assertEquals("", definition.parseValueFromDB(""));
+    }
+
+    @ParameterizedTest
+    @MethodSource("optionalReferenceDefinitions")
+    void shouldParseNumericReference(SystemConfigDefinition<String> definition) throws ResponseException {
+        assertEquals("42", definition.parseValueFromDB("42"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("optionalReferenceDefinitions")
+    void shouldRejectNonNumericReference(SystemConfigDefinition<String> definition) {
+        assertThrows(ResponseException.class, () -> definition.parseValueFromDB("invalid"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("optionalReferenceDefinitions")
+    void shouldSaveFirstSelection(SystemConfigDefinition<String> definition) throws ResponseException {
+        var repository = mock(SystemConfigRepository.class);
+        var service = new SystemConfigService(repository, List.of(definition));
+        var entity = new SystemConfigEntity().setValue("42");
+
+        when(repository.findById(definition.getKey())).thenReturn(Optional.empty());
+
+        service.save(definition.getKey(), entity, true);
+
+        verify(repository).save(entity);
+    }
+
+    @ParameterizedTest
+    @MethodSource("optionalReferenceDefinitions")
+    void shouldClearSelection(SystemConfigDefinition<String> definition) throws ResponseException {
+        var repository = mock(SystemConfigRepository.class);
+        var service = new SystemConfigService(repository, List.of(definition));
+        var entity = new SystemConfigEntity().setValue("");
+
+        when(repository.findById(definition.getKey())).thenReturn(Optional.of(
+                new SystemConfigEntity()
+                        .setKey(definition.getKey())
+                        .setValue("42")
+                        .setPublicConfig(definition.isPublicConfig())
+        ));
+
+        service.save(definition.getKey(), entity, true);
+
+        verify(repository).save(entity);
+    }
+}


### PR DESCRIPTION
## Problem

Several application settings could not be saved:

- Imprint department
- Privacy policy department
- Accessibility statement department
- Global theme
- Public listing switches

Optional references use an empty string to represent an unconfigured value. Their parsers nevertheless attempted to parse every value as a numeric ID. This also caused the first update to fail when the previous value was the empty default.

Boolean settings were affected by a separate type mismatch: the API receives serialized string values, but passed them through a typed Boolean serializer.

## Changes

- Allow empty strings for optional department and theme references.
- Keep numeric validation for configured reference IDs.
- Preserve the serialized string representation at the SystemConfig request boundary.
- Reject `null` request values while continuing to allow explicit empty strings.
- Document the empty-string and request-serialization contracts.
- Keep required storage provider and system role references strictly validated.
- Add regression tests for optional references and serialized Boolean values.

OP#972