### PR TITLE
fix(process): persist task statuses with stable database values

### DIFF
--- a/backend/src/main/java/de/aivot/gover/backend/process/converters/ProcessTaskStatusConverter.java
+++ b/backend/src/main/java/de/aivot/gover/backend/process/converters/ProcessTaskStatusConverter.java
@@ -1,0 +1,37 @@
+package de.aivot.gover.backend.process.converters;
+
+import de.aivot.gover.backend.process.enums.ProcessTaskStatus;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Converter
+public class ProcessTaskStatusConverter implements AttributeConverter<ProcessTaskStatus, Short> {
+    private static final Map<Short, ProcessTaskStatus> STATUSES_BY_DATABASE_VALUE = Arrays
+            .stream(ProcessTaskStatus.values())
+            .collect(Collectors.toUnmodifiableMap(
+                    ProcessTaskStatus::getDatabaseValue,
+                    status -> status
+            ));
+
+    @Override
+    public Short convertToDatabaseColumn(ProcessTaskStatus status) {
+        return status == null ? null : status.getDatabaseValue();
+    }
+
+    @Override
+    public ProcessTaskStatus convertToEntityAttribute(Short databaseValue) {
+        if (databaseValue == null) {
+            return null;
+        }
+
+        var status = STATUSES_BY_DATABASE_VALUE.get(databaseValue);
+        if (status == null) {
+            throw new IllegalArgumentException("Unknown process task status database value: " + databaseValue);
+        }
+        return status;
+    }
+}

--- a/backend/src/main/java/de/aivot/gover/backend/process/converters/ProcessTaskStatusConverter.java
+++ b/backend/src/main/java/de/aivot/gover/backend/process/converters/ProcessTaskStatusConverter.java
@@ -8,6 +8,9 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+/**
+ * Persists task statuses with explicit values so changes to the enum declaration order do not alter stored data.
+ */
 @Converter
 public class ProcessTaskStatusConverter implements AttributeConverter<ProcessTaskStatus, Short> {
     private static final Map<Short, ProcessTaskStatus> STATUSES_BY_DATABASE_VALUE = Arrays

--- a/backend/src/main/java/de/aivot/gover/backend/process/entities/ProcessInstanceTaskEntity.java
+++ b/backend/src/main/java/de/aivot/gover/backend/process/entities/ProcessInstanceTaskEntity.java
@@ -1,6 +1,7 @@
 package de.aivot.gover.backend.process.entities;
 
 import de.aivot.gover.backend.core.converters.JsonObjectConverter;
+import de.aivot.gover.backend.process.converters.ProcessTaskStatusConverter;
 import de.aivot.gover.backend.process.enums.ProcessTaskStatus;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
@@ -58,6 +59,7 @@ public class ProcessInstanceTaskEntity {
     @Nonnull
     @NotNull(message = "Der Aufgaben-Status darf nicht null sein.")
     @Column(columnDefinition = "int2")
+    @Convert(converter = ProcessTaskStatusConverter.class)
     private ProcessTaskStatus status;
 
     @Nullable

--- a/backend/src/main/java/de/aivot/gover/backend/process/enums/ProcessTaskStatus.java
+++ b/backend/src/main/java/de/aivot/gover/backend/process/enums/ProcessTaskStatus.java
@@ -2,16 +2,18 @@ package de.aivot.gover.backend.process.enums;
 
 /**
  * Task status values persisted in {@code process_instance_tasks.status}.
- * Database values must not be changed or reused.
+ * They preserve the ordinal values used before explicit conversion was introduced, so declaration and database order
+ * intentionally differ.
+ * Existing database values must not be changed or reused; new statuses need a new value.
  */
 public enum ProcessTaskStatus {
     Running(0),
     Paused(1),
-    AwaitingPayment(2),
-    Completed(3),
-    Aborted(4),
-    Failed(5),
-    Restarted(6),
+    AwaitingPayment(6),
+    Completed(2),
+    Aborted(3),
+    Failed(4),
+    Restarted(5),
     ;
 
     private final short databaseValue;

--- a/backend/src/main/java/de/aivot/gover/backend/process/enums/ProcessTaskStatus.java
+++ b/backend/src/main/java/de/aivot/gover/backend/process/enums/ProcessTaskStatus.java
@@ -1,11 +1,29 @@
 package de.aivot.gover.backend.process.enums;
 
+/**
+ * Task status values persisted in {@code process_instance_tasks.status}.
+ * Database values must not be changed or reused.
+ */
 public enum ProcessTaskStatus {
-    Running,
-    Paused,
-    AwaitingPayment,
-    Completed,
-    Aborted,
-    Failed,
-    Restarted,
+    Running(0),
+    Paused(1),
+    AwaitingPayment(2),
+    Completed(3),
+    Aborted(4),
+    Failed(5),
+    Restarted(6),
+    ;
+
+    private final short databaseValue;
+
+    ProcessTaskStatus(int databaseValue) {
+        if (databaseValue < Short.MIN_VALUE || databaseValue > Short.MAX_VALUE) {
+            throw new IllegalArgumentException("Process task status database value must fit into a smallint");
+        }
+        this.databaseValue = (short) databaseValue;
+    }
+
+    public short getDatabaseValue() {
+        return databaseValue;
+    }
 }

--- a/backend/src/main/resources/db/migration/V19_2_0__process_instances.sql
+++ b/backend/src/main/resources/db/migration/V19_2_0__process_instances.sql
@@ -85,13 +85,14 @@ create table process_instance_tasks
     previous_process_node_port_key    varchar(96) null,
 
     -- The status of this process task
-    -- Options are:
+    -- Values are stable and mapped by ProcessTaskStatusConverter:
     --   0 - Running
     --   1 - Paused
-    --   2 - Waiting for retry
+    --   2 - Awaiting payment
     --   3 - Completed (this node reached an end state)
     --   4 - Aborted (by user)
     --   5 - Failed
+    --   6 - Restarted
     status                            smallint    not null default 0,
     -- The status override triggered by nodes
     status_override                   varchar(96) null,

--- a/backend/src/main/resources/db/migration/V19_2_0__process_instances.sql
+++ b/backend/src/main/resources/db/migration/V19_2_0__process_instances.sql
@@ -88,11 +88,11 @@ create table process_instance_tasks
     -- Values are stable and mapped by ProcessTaskStatusConverter:
     --   0 - Running
     --   1 - Paused
-    --   2 - Awaiting payment
-    --   3 - Completed (this node reached an end state)
-    --   4 - Aborted (by user)
-    --   5 - Failed
-    --   6 - Restarted
+    --   2 - Completed (this node reached an end state)
+    --   3 - Aborted (by user)
+    --   4 - Failed
+    --   5 - Restarted
+    --   6 - Awaiting payment
     status                            smallint    not null default 0,
     -- The status override triggered by nodes
     status_override                   varchar(96) null,

--- a/backend/src/main/resources/db/migration/V29_2_0__process_task_diff.sql
+++ b/backend/src/main/resources/db/migration/V29_2_0__process_task_diff.sql
@@ -116,5 +116,5 @@ create trigger trg_process_task_completion
     after insert or update of status
     on process_instance_tasks
     for each row
-    when (NEW.status = 3) -- 3 is the status ProcessTaskStatus.Completed
+    when (NEW.status = 3) -- Stable database value of ProcessTaskStatus.Completed
 execute function handle_process_task_completion();

--- a/backend/src/main/resources/db/migration/V29_2_0__process_task_diff.sql
+++ b/backend/src/main/resources/db/migration/V29_2_0__process_task_diff.sql
@@ -116,5 +116,5 @@ create trigger trg_process_task_completion
     after insert or update of status
     on process_instance_tasks
     for each row
-    when (NEW.status = 3) -- Stable database value of ProcessTaskStatus.Completed
+    when (NEW.status = 2) -- Stable database value of ProcessTaskStatus.Completed
 execute function handle_process_task_completion();

--- a/backend/src/test/java/de/aivot/gover/backend/process/converters/ProcessTaskStatusConverterTest.java
+++ b/backend/src/test/java/de/aivot/gover/backend/process/converters/ProcessTaskStatusConverterTest.java
@@ -19,13 +19,14 @@ class ProcessTaskStatusConverterTest {
         var expectedValues = Map.of(
                 ProcessTaskStatus.Running, 0,
                 ProcessTaskStatus.Paused, 1,
-                ProcessTaskStatus.AwaitingPayment, 2,
-                ProcessTaskStatus.Completed, 3,
-                ProcessTaskStatus.Aborted, 4,
-                ProcessTaskStatus.Failed, 5,
-                ProcessTaskStatus.Restarted, 6
+                ProcessTaskStatus.AwaitingPayment, 6,
+                ProcessTaskStatus.Completed, 2,
+                ProcessTaskStatus.Aborted, 3,
+                ProcessTaskStatus.Failed, 4,
+                ProcessTaskStatus.Restarted, 5
         );
 
+        assertEquals(ProcessTaskStatus.values().length, expectedValues.size());
         expectedValues.forEach((status, databaseValue) -> {
             assertEquals(databaseValue.shortValue(), converter.convertToDatabaseColumn(status));
             assertEquals(status, converter.convertToEntityAttribute(databaseValue.shortValue()));

--- a/backend/src/test/java/de/aivot/gover/backend/process/converters/ProcessTaskStatusConverterTest.java
+++ b/backend/src/test/java/de/aivot/gover/backend/process/converters/ProcessTaskStatusConverterTest.java
@@ -1,0 +1,61 @@
+package de.aivot.gover.backend.process.converters;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import de.aivot.gover.backend.core.services.ObjectMapperFactory;
+import de.aivot.gover.backend.process.enums.ProcessTaskStatus;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ProcessTaskStatusConverterTest {
+    private final ProcessTaskStatusConverter converter = new ProcessTaskStatusConverter();
+
+    @Test
+    void convertsStatusesUsingStableDatabaseValues() {
+        var expectedValues = Map.of(
+                ProcessTaskStatus.Running, 0,
+                ProcessTaskStatus.Paused, 1,
+                ProcessTaskStatus.AwaitingPayment, 2,
+                ProcessTaskStatus.Completed, 3,
+                ProcessTaskStatus.Aborted, 4,
+                ProcessTaskStatus.Failed, 5,
+                ProcessTaskStatus.Restarted, 6
+        );
+
+        expectedValues.forEach((status, databaseValue) -> {
+            assertEquals(databaseValue.shortValue(), converter.convertToDatabaseColumn(status));
+            assertEquals(status, converter.convertToEntityAttribute(databaseValue.shortValue()));
+        });
+    }
+
+    @Test
+    void preservesNullValues() {
+        assertNull(converter.convertToDatabaseColumn(null));
+        assertNull(converter.convertToEntityAttribute(null));
+    }
+
+    @Test
+    void rejectsUnknownDatabaseValues() {
+        var exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> converter.convertToEntityAttribute((short) 99)
+        );
+
+        assertEquals("Unknown process task status database value: 99", exception.getMessage());
+    }
+
+    @Test
+    void keepsEnumNamesForJsonSerialization() throws JsonProcessingException {
+        var objectMapper = ObjectMapperFactory.getInstance();
+
+        assertEquals("\"Completed\"", objectMapper.writeValueAsString(ProcessTaskStatus.Completed));
+        assertEquals(
+                ProcessTaskStatus.Completed,
+                objectMapper.readValue("\"Completed\"", ProcessTaskStatus.class)
+        );
+    }
+}


### PR DESCRIPTION
## Context

Adding `AwaitingPayment` before `Completed` changed the JPA ordinal of `ProcessTaskStatus.Completed` from `2` to `3`.

The process data diff trigger depends on the persisted value of `Completed`. As a result, changes to the process data were no longer captured reliably when a task was completed.

## Changes

- Add explicit, stable database values to `ProcessTaskStatus`
- Add a JPA `AttributeConverter` for persistence as PostgreSQL `smallint`
- Preserve the previously persisted status values:
  - `Running = 0`
  - `Paused = 1`
  - `Completed = 2`
  - `Aborted = 3`
  - `Failed = 4`
  - `Restarted = 5`
  - `AwaitingPayment = 6`
- Update the process data diff trigger to use the stable value of `Completed`
- Correct the outdated `Waiting for retry` migration comment
- Keep JSON serialization based on enum names
- Add tests covering all mappings, null handling, unknown values, and JSON serialization

## Migration notes

No existing status values need to be remapped. The converter preserves the ordinal values that were persisted before `AwaitingPayment` was introduced.

The existing migrations are adjusted directly because this version has not been deployed yet.