### PR TITLE
chore: update ClamAV to 1.5.4 and clean up Docker configuration

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM node:24.2.0-alpine3.21 AS build_mails
+FROM docker.io/library/node:24.2.0-alpine3.21 AS build_mails
 
 # Set working directory
 WORKDIR /mails
@@ -12,7 +12,7 @@ RUN npm install
 # Build mails
 RUN npm run build:prod
 
-FROM node:24.2.0-alpine3.21 AS build_app
+FROM docker.io/library/node:24.2.0-alpine3.21 AS build_app
 
 # Set build version and date
 ARG BUILD_VERSION=0.0.0
@@ -42,7 +42,7 @@ RUN npm run build:staff
 # Build customer app
 RUN npm run build:customer
 
-FROM  maven:3.9.9-eclipse-temurin-21-alpine AS build_server
+FROM  docker.io/library/maven:3.9.9-eclipse-temurin-21-alpine AS build_server
 
 # Set build version and date
 ARG BUILD_VERSION=0.0.0
@@ -70,7 +70,7 @@ COPY --from=build_mails /mails/dist src/main/resources/templates/mail
 RUN mvn install -DskipTests
 
 # App
-FROM eclipse-temurin:21.0.10_7-jre-alpine-3.21
+FROM docker.io/library/eclipse-temurin:21.0.10_7-jre-alpine-3.21
 
 # Set build version and date
 ARG BUILD_VERSION=0.0.0

--- a/backend/src/test/java/de/aivot/prosuna/backend/av/services/AVServiceTest.java
+++ b/backend/src/test/java/de/aivot/prosuna/backend/av/services/AVServiceTest.java
@@ -2,7 +2,6 @@ package de.aivot.prosuna.backend.av.services;
 
 import de.aivot.prosuna.backend.av.exceptions.AVCheckFailedException;
 import de.aivot.prosuna.backend.av.exceptions.AVVirusFoundException;
-import de.aivot.prosuna.backend.av.services.AVService;
 import de.aivot.prosuna.backend.lib.exceptions.ResponseException;
 import de.aivot.prosuna.backend.models.config.ClamConfig;
 import de.aivot.prosuna.backend.models.config.ProsunaConfig;
@@ -11,14 +10,66 @@ import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
 import java.io.IOException;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AVServiceTest {
+    @Test
+    void testServiceStatusShouldUseClamdPingProtocol() throws Exception {
+        try (var scanner = new ServerSocket(0)) {
+            var scannerTask = startScannerTask(scanner, socket -> {
+                var command = socket.getInputStream().readNBytes("zPING\0".length());
+                assertArrayEquals("zPING\0".getBytes(StandardCharsets.US_ASCII), command);
+
+                socket.getOutputStream().write("PONG\0".getBytes(StandardCharsets.US_ASCII));
+                socket.getOutputStream().flush();
+            });
+
+            assertTrue(createService(scanner).testServiceStatus());
+            scannerTask.get(5, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void testFileShouldUseClamdInstreamProtocol() throws Exception {
+        var content = new byte[9000];
+        Arrays.fill(content, (byte) 'a');
+
+        try (var scanner = new ServerSocket(0)) {
+            var scannerTask = startScannerTask(scanner, socket -> {
+                var input = new DataInputStream(socket.getInputStream());
+                var command = input.readNBytes("zINSTREAM\0".length());
+                assertArrayEquals("zINSTREAM\0".getBytes(StandardCharsets.US_ASCII), command);
+
+                var receivedContent = new ByteArrayOutputStream();
+                int chunkLength;
+                while ((chunkLength = input.readInt()) != 0) {
+                    receivedContent.write(input.readNBytes(chunkLength));
+                }
+                assertArrayEquals(content, receivedContent.toByteArray());
+
+                socket.getOutputStream().write("stream: OK\0".getBytes(StandardCharsets.US_ASCII));
+                socket.getOutputStream().flush();
+            });
+
+            createService(scanner).testFile(new ByteArrayInputStream(content), "clean.txt");
+            scannerTask.get(5, TimeUnit.SECONDS);
+        }
+    }
+
     @Test
     void parseScannerPortShouldRejectInvalidValues() {
         assertThrows(IOException.class, () -> AVService.parseScannerPort("invalid"));
@@ -64,5 +115,29 @@ class AVServiceTest {
 
         assertEquals(HttpStatus.NOT_ACCEPTABLE, exception.getStatus());
         assertEquals("Die Dateiendung des Anhangs \"report.exe\" ist nicht erlaubt.", exception.getTitle());
+    }
+
+    private static AVService createService(ServerSocket scanner) {
+        var clamConfig = new ClamConfig();
+        clamConfig.setHost("127.0.0.1");
+        clamConfig.setPort(String.valueOf(scanner.getLocalPort()));
+        clamConfig.setTimeout(2000);
+        return new AVService(new ProsunaConfig(), clamConfig);
+    }
+
+    private static FutureTask<Void> startScannerTask(ServerSocket scanner, SocketHandler handler) {
+        var task = new FutureTask<Void>(() -> {
+            try (var socket = scanner.accept()) {
+                handler.handle(socket);
+            }
+            return null;
+        });
+        Thread.ofVirtual().start(task);
+        return task;
+    }
+
+    @FunctionalInterface
+    private interface SocketHandler {
+        void handle(java.net.Socket socket) throws Exception;
     }
 }

--- a/compose.yml
+++ b/compose.yml
@@ -15,7 +15,7 @@ services:
 
 
   prosuna_database:
-    image: postgres:15.18
+    image: docker.io/library/postgres:15.18
     restart: always
     environment:
       POSTGRES_PASSWORD: "{{ PROSUNA_DB_PASSWORD }}" # Setzen Sie das Passwort für die Prosuna-Datenbank. Passen Sie dieses Passwort unbedingt an.
@@ -30,7 +30,7 @@ services:
 
 
   keycloak_database:
-    image: postgres:15.18
+    image: docker.io/library/postgres:15.18
     restart: always
     environment:
       POSTGRES_PASSWORD: "{{ KEYCLOAK_DB_PASSWORD }}" # Setzen Sie das Passwort für die Keycloak-Datenbank. Passen Sie dieses Passwort unbedingt an.
@@ -51,14 +51,14 @@ services:
 
 
   redis:
-    image: redis:7.4.9
+    image: docker.io/library/redis:7.4.9
     restart: always
     networks:
       - prosuna
 
 
   gotenberg:
-    image: gotenberg/gotenberg:8
+    image: docker.io/gotenberg/gotenberg:8
     restart: always
     environment:
       CHROMIUM_DENY_PRIVATE_IPS: "true"
@@ -259,7 +259,7 @@ services:
 
 
   traefik:
-    image: traefik:2.11.46
+    image: docker.io/library/traefik:2.11.46
     restart: always
     command:
       - --providers.docker

--- a/compose.yml
+++ b/compose.yml
@@ -44,7 +44,7 @@ services:
 
 
   clamav:
-    image: clamav/clamav-debian:1.5.2
+    image: docker.io/clamav/clamav:1.5.4-debian
     restart: always
     networks:
       - prosuna

--- a/development/compose.yml
+++ b/development/compose.yml
@@ -19,7 +19,7 @@ services:
       - "5432:5432"
 
   antivirus:
-    image: clamav/clamav-debian:1.5.1
+    image: docker.io/clamav/clamav:1.5.4-debian
     restart: unless-stopped
     ports:
       - "3310:3310"

--- a/development/compose.yml
+++ b/development/compose.yml
@@ -6,7 +6,7 @@ name: prosuna_dev_environment
 services:
 
   prosuna-database:
-    image: postgres:16.12-alpine3.23
+    image: docker.io/library/postgres:16.12-alpine3.23
     restart: unless-stopped
     environment:
       POSTGRES_PASSWORD: prosuna
@@ -25,20 +25,20 @@ services:
       - "3310:3310"
 
   cache:
-    image: redis:8.2.4-alpine3.22
+    image: docker.io/library/redis:8.2.4-alpine3.22
     restart: unless-stopped
     ports:
       - "6379:6379"
 
   pdf-printer:
-    image: gotenberg/gotenberg:8.26.0
+    image: docker.io/gotenberg/gotenberg:8.26.0
     restart: unless-stopped
     network_mode: host
     environment:
       API_PORT: 9191
 
   s3-object-storage:
-    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    image: docker.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     restart: unless-stopped
     command: server /data --console-address ":9001"
     environment:
@@ -51,7 +51,7 @@ services:
       - "9001:9001"
 
   s3-object-storage-setup:
-    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
     depends_on:
       - s3-object-storage
     entrypoint: >
@@ -63,7 +63,7 @@ services:
       "
 
   smtp:
-    image: axllent/mailpit:v1.29.1
+    image: docker.io/axllent/mailpit:v1.29.1
     restart: unless-stopped
     environment:
       MP_MAX_MESSAGES: 5000
@@ -77,7 +77,7 @@ services:
       - "2025:1025"
 
   keycloak-database:
-    image: postgres:16.12-alpine3.23
+    image: docker.io/library/postgres:16.12-alpine3.23
     restart: unless-stopped
     environment:
       POSTGRES_PASSWORD: keycloak
@@ -136,7 +136,7 @@ services:
       BACKEND_CLIENT_SECRET: "my-super-secret-key"
 
   message-broker:
-    image: rabbitmq:4.2.4-management-alpine
+    image: docker.io/library/rabbitmq:4.2.4-management-alpine
     restart: unless-stopped
     environment:
       RABBITMQ_DEFAULT_USER: admin
@@ -148,7 +148,7 @@ services:
       - rabbitmq_data:/var/lib/rabbitmq
 
   reverse-proxy:
-    image: caddy:2.10.2-alpine
+    image: docker.io/library/caddy:2.10.2-alpine
     restart: unless-stopped
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:Z

--- a/examples/local/compose.yml
+++ b/examples/local/compose.yml
@@ -71,7 +71,7 @@ services:
       PROSUNA_HOSTNAME: http://localhost:9595
 
   prosuna_database:
-    image: docker.io/postgres:18-alpine
+    image: docker.io/library/postgres:18-alpine
     restart: unless-stopped
     environment:
       POSTGRES_PASSWORD: ${PROSUNA_DB_PASSWORD}
@@ -137,7 +137,7 @@ services:
       - keycloak
 
   keycloak_database:
-    image: docker.io/postgres:18-alpine
+    image: docker.io/library/postgres:18-alpine
     restart: unless-stopped
     environment:
       POSTGRES_PASSWORD: ${KEYCLOAK_DB_PASSWORD}
@@ -156,7 +156,7 @@ services:
       - prosuna
 
   redis:
-    image: docker.io/redis:8-alpine
+    image: docker.io/library/redis:8-alpine
     restart: unless-stopped
     networks:
       - prosuna
@@ -190,7 +190,7 @@ services:
       - mail
 
   rabbitmq:
-    image: docker.io/rabbitmq:4-alpine
+    image: docker.io/library/rabbitmq:4-alpine
     restart: unless-stopped
     environment:
       RABBITMQ_DEFAULT_USER: prosuna
@@ -201,7 +201,7 @@ services:
       - prosuna
 
   caddy:
-    image: docker.io/caddy:2-alpine
+    image: docker.io/library/caddy:2-alpine
     restart: unless-stopped
     depends_on:
       prosuna_api:

--- a/examples/local/compose.yml
+++ b/examples/local/compose.yml
@@ -150,7 +150,7 @@ services:
       - keycloak
 
   clamav:
-    image: docker.io/clamav/clamav:1.5-debian
+    image: docker.io/clamav/clamav:1.5.4-debian
     restart: unless-stopped
     networks:
       - prosuna

--- a/examples/server/compose.yml
+++ b/examples/server/compose.yml
@@ -73,7 +73,7 @@ services:
       - proxy
 
   prosuna_database:
-    image: docker.io/postgres:18-alpine
+    image: docker.io/library/postgres:18-alpine
     restart: unless-stopped
     environment:
       POSTGRES_PASSWORD: ${PROSUNA_DB_PASSWORD}
@@ -141,7 +141,7 @@ services:
       - keycloak
 
   keycloak_database:
-    image: docker.io/postgres:18-alpine
+    image: docker.io/library/postgres:18-alpine
     restart: unless-stopped
     environment:
       POSTGRES_PASSWORD: ${KEYCLOAK_DB_PASSWORD}
@@ -160,7 +160,7 @@ services:
       - prosuna
 
   redis:
-    image: docker.io/redis:8-alpine
+    image: docker.io/library/redis:8-alpine
     restart: unless-stopped
     networks:
       - prosuna
@@ -180,7 +180,7 @@ services:
       - prosuna
 
   rabbitmq:
-    image: docker.io/rabbitmq:4-alpine
+    image: docker.io/library/rabbitmq:4-alpine
     restart: unless-stopped
     environment:
       RABBITMQ_DEFAULT_USER: prosuna
@@ -191,7 +191,7 @@ services:
       - prosuna
 
   caddy:
-    image: docker.io/caddy:2-alpine
+    image: docker.io/library/caddy:2-alpine
     restart: unless-stopped
     depends_on:
       prosuna_api:

--- a/examples/server/compose.yml
+++ b/examples/server/compose.yml
@@ -155,7 +155,7 @@ services:
       - keycloak
 
   clamav:
-    image: docker.io/clamav/clamav:1.5-debian
+    image: docker.io/clamav/clamav:1.5.4-debian
     restart: unless-stopped
     networks:
       - prosuna

--- a/examples/server/compose.yml
+++ b/examples/server/compose.yml
@@ -11,7 +11,6 @@ services:
       - clamav
       - redis
       - rabbitmq
-      - gotenberg
     environment:
       PROSUNA_SERVER_PORT: 9595
       PROSUNA_DB_HOST: prosuna_database

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -12,7 +12,7 @@ if [ ! -f .env ]; then
 fi
 
 # Container Images
-postgres_image="docker.io/postgres:18.3-alpine3.23"
+postgres_image="docker.io/library/postgres:18.3-alpine3.23"
 clamav_image="docker.io/clamav/clamav:1.5.4-debian"
 redis_image="registry.opencode.de/open-code/oci/redis:8.2.3"
 gotenberg_image="docker.io/gotenberg/gotenberg:8.30.1-chromium"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -13,7 +13,7 @@ fi
 
 # Container Images
 postgres_image="docker.io/postgres:18.3-alpine3.23"
-clamav_image="registry.opencode.de/open-code/oci/clamav:1.4.3"
+clamav_image="docker.io/clamav/clamav:1.5.4-debian"
 redis_image="registry.opencode.de/open-code/oci/redis:8.2.3"
 gotenberg_image="docker.io/gotenberg/gotenberg:8.30.1-chromium"
 rabbitmq_image="dhi.io/rabbitmq:4.2"


### PR DESCRIPTION
## Summary

- Replace deprecated and outdated ClamAV images with `docker.io/clamav/clamav:1.5.4-debian` across all Docker setups
- Add lightweight socket-level contract tests for the clamd `PING` and `INSTREAM` protocols
- Remove the circular dependency between the Prosuna API and Gotenberg in server example
- Fully qualify Docker Hub image references, including the canonical `library` namespace for official images

## Verification

- Full backend test suite: 949 tests passed
- Validated all four Compose configurations
- Validated `tools/install.sh` syntax
- Ran the Docker build check without warnings
- Confirmed ClamAV 1.5.4 starts successfully on ARM64, responds to `PING`, and completes a clean file scan