### PR TITLE
feat: add login timeout screen

### DIFF
--- a/backend/src/main/java/de/aivot/prosuna/backend/system/controllers/AuthController.java
+++ b/backend/src/main/java/de/aivot/prosuna/backend/system/controllers/AuthController.java
@@ -16,7 +16,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.web.csrf.CsrfTokenRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
@@ -33,7 +35,7 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 
-@RestController
+@Controller
 @RequestMapping("/api/auth/")
 @Tag(name = "Authentication", description = "Endpoints for user authentication")
 public class AuthController {
@@ -62,6 +64,19 @@ public class AuthController {
     private static final String OIDC_REFRESH_TOKEN_PARAM_KEY = "refresh_token";
 
     private static final String OIDC_CALLBACK_CODE_PARAM_KEY = "code";
+    private static final String DEFAULT_APP_URI = "/staff";
+    private static final String CALLBACK_ERROR_VIEW = "auth/oidc-callback-error";
+    private static final String MISSING_AUTHORIZATION_CODE_MESSAGE = "Es wurde kein Autorisierungscode übergeben.";
+    private static final String INVALID_STATE_MESSAGE = "Der state-Parameter ist ungültig.";
+    private static final String EXPIRED_AUTH_FLOW_MESSAGE = "Die Authentifizierungssitzung ist abgelaufen.";
+    private static final String INVALID_APP_REDIRECT_MESSAGE = "Die App-Weiterleitungsadresse ist ungültig.";
+    private static final String DISALLOWED_APP_REDIRECT_MESSAGE = "Die App-Weiterleitungsadresse ist nicht erlaubt.";
+
+    private static final String MISSING_AUTHORIZATION_CODE_DESCRIPTION = "Der Identitätsanbieter hat keinen Autorisierungscode zurückgegeben. Ohne diesen Code kann Prosuna keine Sitzung erstellen. Starten Sie die Anmeldung erneut.";
+    private static final String INVALID_STATE_DESCRIPTION = "Die Sicherheitsprüfung der Anmeldung ist fehlgeschlagen. Das kann passieren, wenn der Link aus einem alten Browser-Tab stammt, Cookies fehlen oder parallel eine neue Anmeldung gestartet wurde.";
+    private static final String EXPIRED_AUTH_FLOW_DESCRIPTION = "Ihre Anmeldesitzung ist abgelaufen. Starten Sie die Anmeldung erneut, damit eine neue sichere Sitzung erstellt wird.";
+    private static final String INVALID_APP_REDIRECT_DESCRIPTION = "Die gespeicherte Rücksprungadresse der Anwendung ist ungültig oder nicht erlaubt. Die Anmeldung kann über den Standardbereich neu gestartet werden.";
+    private static final String TOKEN_EXCHANGE_ERROR_DESCRIPTION = "Der Identitätsanbieter hat geantwortet, aber Prosuna konnte die Anmeldung nicht abschließen. Bitte versuchen Sie es später erneut oder wenden Sie sich an den Support, falls der Fehler bestehen bleibt.";
 
     public static final String ACCESS_COOKIE_NAME = "access";
     public static final String REFRESH_COOKIE_NAME = "refresh";
@@ -164,6 +179,7 @@ public class AuthController {
     }
 
     @GetMapping("refresh")
+    @ResponseBody
     @Operation(
             summary = "Login",
             description = "Redirects the user to the authentication provider login page or directly to the specified redirect URL if already authenticated."
@@ -197,19 +213,35 @@ public class AuthController {
             summary = "Login",
             description = "Redirects the user to the authentication provider login page or directly to the specified redirect URL if already authenticated."
     )
-    public void idpCallback(
+    public ModelAndView idpCallback(
             @Nonnull HttpServletResponse response,
             @Nullable @RequestParam(value = OIDC_STATE_PARAM_KEY, required = false) String state,
             @Nullable @RequestParam(value = OIDC_CALLBACK_CODE_PARAM_KEY, required = false) String code,
             @Nullable @CookieValue(value = AUTH_FLOW_COOKIE_NAME, required = false) String authFlowState
-    ) throws ResponseException, IOException {
+    ) {
         try {
             if (StringUtils.isNullOrEmpty(code)) {
-                throw ResponseException.badRequest("Es wurde kein Autorisierungscode übergeben.");
+                return getIdpCallbackErrorView(
+                        response,
+                        ResponseException.badRequest(MISSING_AUTHORIZATION_CODE_MESSAGE),
+                        MISSING_AUTHORIZATION_CODE_DESCRIPTION,
+                        getRestartLoginUrl(getAppUriForRestart(state, authFlowState))
+                );
             }
 
-            var flowState = consumeAuthFlowState(state, authFlowState);
-            var appRedirectLocation = resolveAppRedirectLocation(flowState.appUri);
+            AuthFlowState flowState;
+            try {
+                flowState = consumeAuthFlowState(state, authFlowState);
+            } catch (ResponseException e) {
+                return getIdpCallbackErrorView(response, e, getStateErrorDescription(e), getRestartLoginUrl(DEFAULT_APP_URI));
+            }
+
+            String appRedirectLocation;
+            try {
+                appRedirectLocation = resolveAppRedirectLocation(flowState.appUri);
+            } catch (ResponseException e) {
+                return getIdpCallbackErrorView(response, e, INVALID_APP_REDIRECT_DESCRIPTION, getRestartLoginUrl(DEFAULT_APP_URI));
+            }
 
             var payload = new HashMap<String, String>();
             payload.put(OIDC_GRANT_TYPE_PARAM_KEY, OIDC_GRANT_TYPE_VALUE);
@@ -223,7 +255,12 @@ public class AuthController {
                 payload.put(OIDC_CLIENT_SECRET_PARAM_KEY, oidcClientSecret);
             }
 
-            TokenResponse tokenResponse = getTokenResponse(payload);
+            TokenResponse tokenResponse;
+            try {
+                tokenResponse = getTokenResponse(payload);
+            } catch (ResponseException e) {
+                return getIdpCallbackErrorView(response, e, TOKEN_EXCHANGE_ERROR_DESCRIPTION, null);
+            }
 
             var refreshCookie = getRefreshCookie(tokenResponse);
             response.addCookie(refreshCookie);
@@ -231,7 +268,7 @@ public class AuthController {
             var accessCookie = getAccessCookie(tokenResponse);
             response.addCookie(accessCookie);
 
-            response.sendRedirect(appRedirectLocation);
+            return new ModelAndView("redirect:" + appRedirectLocation);
         } finally {
             response.addCookie(getExpiredAuthFlowCookie());
         }
@@ -308,16 +345,80 @@ public class AuthController {
     }
 
     @Nonnull
+    private ModelAndView getIdpCallbackErrorView(
+            @Nonnull HttpServletResponse response,
+            @Nonnull ResponseException exception,
+            @Nonnull String description,
+            @Nullable String restartLoginUrl
+    ) {
+        response.setStatus(exception.getStatus().value());
+
+        var modelAndView = new ModelAndView(CALLBACK_ERROR_VIEW);
+        modelAndView.setStatus(exception.getStatus());
+        modelAndView.addObject("message", exception.getTitle());
+        modelAndView.addObject("description", description);
+
+        if (StringUtils.isNotNullOrEmpty(restartLoginUrl)) {
+            modelAndView.addObject("restartLoginUrl", restartLoginUrl);
+        }
+
+        return modelAndView;
+    }
+
+    @Nonnull
+    private static String getStateErrorDescription(@Nonnull ResponseException exception) {
+        return EXPIRED_AUTH_FLOW_MESSAGE.equals(exception.getTitle()) ? EXPIRED_AUTH_FLOW_DESCRIPTION : INVALID_STATE_DESCRIPTION;
+    }
+
+    @Nonnull
+    private String getAppUriForRestart(
+            @Nullable String state,
+            @Nullable String authFlowStateCookie
+    ) {
+        if (StringUtils.isNullOrEmpty(state) || StringUtils.isNullOrEmpty(authFlowStateCookie) || !state.equals(authFlowStateCookie)) {
+            return DEFAULT_APP_URI;
+        }
+
+        var value = redis
+                .opsForValue()
+                .get(getAuthFlowRedisKey(state));
+
+        if (value == null) {
+            return DEFAULT_APP_URI;
+        }
+
+        try {
+            var flowState = ObjectMapperFactory
+                    .getInstance()
+                    .readValue(value, AuthFlowState.class);
+            return resolveAppRedirectLocation(flowState.appUri);
+        } catch (JsonProcessingException | ResponseException e) {
+            return DEFAULT_APP_URI;
+        }
+    }
+
+    @Nonnull
+    private static String getRestartLoginUrl(@Nonnull String appUri) {
+        return UriComponentsBuilder
+                .fromPath(AUTH_FLOW_COOKIE_PATH)
+                .path("login")
+                .queryParam(APP_URI_QUERY_PARAM, appUri)
+                .build()
+                .encode()
+                .toUriString();
+    }
+
+    @Nonnull
     private AuthFlowState consumeAuthFlowState(
             @Nullable String state,
             @Nullable String authFlowStateCookie
     ) throws ResponseException {
         if (StringUtils.isNullOrEmpty(state) || StringUtils.isNullOrEmpty(authFlowStateCookie)) {
-            throw ResponseException.badRequest("Der state-Parameter ist ungültig.");
+            throw ResponseException.badRequest(INVALID_STATE_MESSAGE);
         }
 
         if (!state.equals(authFlowStateCookie)) {
-            throw ResponseException.badRequest("Der state-Parameter ist ungültig.");
+            throw ResponseException.badRequest(INVALID_STATE_MESSAGE);
         }
 
         var value = redis
@@ -325,7 +426,7 @@ public class AuthController {
                 .getAndDelete(getAuthFlowRedisKey(state));
 
         if (value == null) {
-            throw ResponseException.badRequest("Die Authentifizierungssitzung ist abgelaufen.");
+            throw ResponseException.badRequest(EXPIRED_AUTH_FLOW_MESSAGE);
         }
 
         try {
@@ -348,22 +449,22 @@ public class AuthController {
         try {
             appRedirectUri = new URI(appUri);
         } catch (URISyntaxException | IllegalArgumentException e) {
-            throw ResponseException.badRequest("Die App-Weiterleitungsadresse ist ungültig.");
+            throw ResponseException.badRequest(INVALID_APP_REDIRECT_MESSAGE);
         }
 
         if (!appRedirectUri.isAbsolute()) {
             if (appUri.startsWith("/") && !appUri.startsWith("//") && appRedirectUri.getRawAuthority() == null) {
                 return appRedirectUri.toString();
             }
-            throw ResponseException.badRequest("Die App-Weiterleitungsadresse ist ungültig.");
+            throw ResponseException.badRequest(INVALID_APP_REDIRECT_MESSAGE);
         }
 
         if (!hasAllowedSchemeAndHost(appRedirectUri)) {
-            throw ResponseException.badRequest("Die App-Weiterleitungsadresse ist ungültig.");
+            throw ResponseException.badRequest(INVALID_APP_REDIRECT_MESSAGE);
         }
 
         if (!hasSameOrigin(appRedirectUri, parseConfiguredAppRedirectOrigin(hostname))) {
-            throw ResponseException.badRequest("Die App-Weiterleitungsadresse ist nicht erlaubt.");
+            throw ResponseException.badRequest(DISALLOWED_APP_REDIRECT_MESSAGE);
         }
 
         return appRedirectUri.toString();

--- a/backend/src/main/resources/templates/auth/oidc-callback-error.html
+++ b/backend/src/main/resources/templates/auth/oidc-callback-error.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html
+        xmlns:th="http://www.thymeleaf.org"
+        lang="de"
+>
+    <head>
+        <title>Anmeldung fehlgeschlagen</title>
+        <meta charset="UTF-8"/>
+        <style>
+            * {
+                box-sizing: border-box;
+            }
+
+            body {
+                align-items: center;
+                background: #fff;
+                color: rgba(0, 0, 0, 0.87);
+                display: flex;
+                font-family: "Public Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+                justify-content: center;
+                margin: 0;
+                min-height: 100vh;
+                padding: 24px;
+                text-align: center;
+            }
+
+            main {
+                max-width: 560px;
+            }
+
+            h1 {
+                font-size: 2rem;
+                font-weight: 400;
+                line-height: 1.2;
+                margin: 0 0 16px;
+            }
+
+            p {
+                font-size: 1rem;
+                line-height: 1.5;
+                margin: 0 0 16px;
+            }
+
+            .description {
+                color: rgba(0, 0, 0, 0.6);
+                margin-bottom: 32px;
+            }
+
+            .restart-button {
+                align-items: center;
+                background-color: #733635;
+                border-radius: 4px;
+                color: #fff;
+                display: inline-flex;
+                font-size: 0.875rem;
+                font-weight: 500;
+                justify-content: center;
+                line-height: 1.75;
+                min-width: 320px;
+                padding: 12px 20px;
+                text-decoration: none;
+                text-transform: none;
+                transition: background-color 150ms ease-in-out, box-shadow 150ms ease-in-out;
+            }
+
+            .restart-button:hover,
+            .restart-button:focus {
+                background-color: #502525;
+                outline: none;
+            }
+
+            .restart-button:focus-visible {
+                outline: 2px solid #9d7271;
+                outline-offset: 2px;
+            }
+        </style>
+    </head>
+    <body>
+        <main>
+            <h1>Anmeldung fehlgeschlagen</h1>
+            <p th:text="${message}">
+                Die Anmeldung konnte nicht abgeschlossen werden.
+            </p>
+            <p
+                    class="description"
+                    th:text="${description}"
+            >
+                Bitte starten Sie die Anmeldung erneut oder versuchen Sie es später noch einmal.
+            </p>
+            <p th:if="${restartLoginUrl != null}">
+                <a
+                        class="restart-button"
+                        th:href="${restartLoginUrl}"
+                >
+                    Anmeldung erneut starten
+                </a>
+            </p>
+        </main>
+    </body>
+</html>

--- a/backend/src/test/java/de/aivot/prosuna/backend/system/controllers/AuthControllerTest.java
+++ b/backend/src/test/java/de/aivot/prosuna/backend/system/controllers/AuthControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.web.csrf.CsrfTokenRepository;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
@@ -163,9 +164,9 @@ class AuthControllerTest {
 
         var response = new MockHttpServletResponse();
 
-        controller.idpCallback(response, "state", "authorization-code", "state");
+        var modelAndView = controller.idpCallback(response, "state", "authorization-code", "state");
 
-        assertEquals("/staff/dashboard", response.getRedirectedUrl());
+        assertEquals("redirect:/staff/dashboard", modelAndView.getViewName());
         assertNotNull(findCookie(response, AuthController.ACCESS_COOKIE_NAME, "/api/"));
         assertNotNull(findCookie(response, AuthController.REFRESH_COOKIE_NAME, "/api/auth/"));
         assertClearsCookie(response, AuthController.AUTH_FLOW_COOKIE_NAME, "/api/auth/");
@@ -179,8 +180,16 @@ class AuthControllerTest {
 
         var response = new MockHttpServletResponse();
 
-        assertThrows(ResponseException.class, () -> controller.idpCallback(response, "state", "authorization-code", "state"));
+        var modelAndView = controller.idpCallback(response, "state", "authorization-code", "state");
 
+        assertCallbackError(
+                modelAndView,
+                response,
+                400,
+                "Die App-Weiterleitungsadresse ist nicht erlaubt.",
+                "Die gespeicherte Rücksprungadresse der Anwendung ist ungültig oder nicht erlaubt. Die Anmeldung kann über den Standardbereich neu gestartet werden.",
+                "/api/auth/login?app_uri=/staff"
+        );
         verifyNoInteractions(httpService);
         assertClearsCookie(response, AuthController.AUTH_FLOW_COOKIE_NAME, "/api/auth/");
     }
@@ -189,8 +198,16 @@ class AuthControllerTest {
     void callbackShouldRejectMismatchedStateWithoutTokenRequest() {
         var response = new MockHttpServletResponse();
 
-        assertThrows(ResponseException.class, () -> controller.idpCallback(response, "state", "code", "other-state"));
+        var modelAndView = controller.idpCallback(response, "state", "code", "other-state");
 
+        assertCallbackError(
+                modelAndView,
+                response,
+                400,
+                "Der state-Parameter ist ungültig.",
+                "Die Sicherheitsprüfung der Anmeldung ist fehlgeschlagen. Das kann passieren, wenn der Link aus einem alten Browser-Tab stammt, Cookies fehlen oder parallel eine neue Anmeldung gestartet wurde.",
+                "/api/auth/login?app_uri=/staff"
+        );
         verify(valueOperations, never()).getAndDelete(anyString());
         verifyNoInteractions(httpService);
         assertClearsCookie(response, AuthController.AUTH_FLOW_COOKIE_NAME, "/api/auth/");
@@ -202,9 +219,66 @@ class AuthControllerTest {
 
         var response = new MockHttpServletResponse();
 
-        assertThrows(ResponseException.class, () -> controller.idpCallback(response, "state", "code", "state"));
+        var modelAndView = controller.idpCallback(response, "state", "code", "state");
 
+        assertCallbackError(
+                modelAndView,
+                response,
+                400,
+                "Die Authentifizierungssitzung ist abgelaufen.",
+                "Ihre Anmeldesitzung ist abgelaufen. Starten Sie die Anmeldung erneut, damit eine neue sichere Sitzung erstellt wird.",
+                "/api/auth/login?app_uri=/staff"
+        );
         verifyNoInteractions(httpService);
+        assertClearsCookie(response, AuthController.AUTH_FLOW_COOKIE_NAME, "/api/auth/");
+    }
+
+    @Test
+    void callbackShouldReuseStoredAppRedirectWhenCodeIsMissing() {
+        when(valueOperations.get("auth:pkce:state")).thenReturn("""
+                {"codeVerifier":"verifier","redirectUri":"https://prosuna.example.com/api/auth/oidc-callback","appUri":"/staff/dashboard"}
+                """);
+
+        var response = new MockHttpServletResponse();
+
+        var modelAndView = controller.idpCallback(response, "state", null, "state");
+
+        assertCallbackError(
+                modelAndView,
+                response,
+                400,
+                "Es wurde kein Autorisierungscode übergeben.",
+                "Der Identitätsanbieter hat keinen Autorisierungscode zurückgegeben. Ohne diesen Code kann Prosuna keine Sitzung erstellen. Starten Sie die Anmeldung erneut.",
+                "/api/auth/login?app_uri=/staff/dashboard"
+        );
+        verifyNoInteractions(httpService);
+        assertClearsCookie(response, AuthController.AUTH_FLOW_COOKIE_NAME, "/api/auth/");
+    }
+
+    @Test
+    void callbackShouldNotShowRestartLinkWhenTokenRequestFails() throws Exception {
+        when(valueOperations.getAndDelete("auth:pkce:state")).thenReturn("""
+                {"codeVerifier":"verifier","redirectUri":"https://prosuna.example.com/api/auth/oidc-callback","appUri":"/staff/dashboard"}
+                """);
+
+        var tokenResponse = mock(HttpResponse.class);
+        when(tokenResponse.statusCode()).thenReturn(500);
+        when(httpService.postFormUrlEncoded(any(), any())).thenReturn(tokenResponse);
+
+        var response = new MockHttpServletResponse();
+
+        var modelAndView = controller.idpCallback(response, "state", "authorization-code", "state");
+
+        assertCallbackError(
+                modelAndView,
+                response,
+                500,
+                "Failed to exchange authorization code for access token. status code: 500",
+                "Der Identitätsanbieter hat geantwortet, aber Prosuna konnte die Anmeldung nicht abschließen. Bitte versuchen Sie es später erneut oder wenden Sie sich an den Support, falls der Fehler bestehen bleibt.",
+                null
+        );
+        assertNull(findCookie(response, AuthController.ACCESS_COOKIE_NAME, "/api/"));
+        assertNull(findCookie(response, AuthController.REFRESH_COOKIE_NAME, "/api/auth/"));
         assertClearsCookie(response, AuthController.AUTH_FLOW_COOKIE_NAME, "/api/auth/");
     }
 
@@ -316,6 +390,21 @@ class AuthControllerTest {
                 .filter(candidate -> path.equals(candidate.getPath()))
                 .findFirst()
                 .orElse(null);
+    }
+
+    private static void assertCallbackError(
+            ModelAndView modelAndView,
+            MockHttpServletResponse response,
+            int status,
+            String message,
+            String description,
+            String restartLoginUrl
+    ) {
+        assertEquals("auth/oidc-callback-error", modelAndView.getViewName());
+        assertEquals(status, response.getStatus());
+        assertEquals(message, modelAndView.getModel().get("message"));
+        assertEquals(description, modelAndView.getModel().get("description"));
+        assertEquals(restartLoginUrl, modelAndView.getModel().get("restartLoginUrl"));
     }
 
     private static void assertClearsCookie(


### PR DESCRIPTION
# Description
When the cached login state expires, the backend showed the generic json api error response. With this PR a new error page is introduced to display the occurred error and, if possible, a recovery path.

# Tickets
- OP#1028