### PR TITLE
build(frontend): Reduce initial JavaScript transfer by over 60%

### DIFF
--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -35,3 +35,13 @@ jobs:
       - name: Run unit tests
         working-directory: app
         run: npm test
+
+      - name: Test asset compression
+        working-directory: app
+        run: npm run test:assets
+
+      - name: Build asset delivery test image
+        run: docker build -f container/Containerfile.nginx-test -t prosuna-nginx-test .
+
+      - name: Test asset delivery
+        run: docker run --rm --network none prosuna-nginx-test

--- a/Containerfile
+++ b/Containerfile
@@ -105,7 +105,7 @@ COPY container/healthcheck.sh /app/healthcheck.sh
 
 # Install locale, nginx, configure nginx and entrypoint script
 RUN apk upgrade --no-cache && \
-    apk add curl tzdata musl musl-utils musl-locales nginx && \
+    apk add curl tzdata musl musl-utils musl-locales nginx nginx-mod-http-brotli && \
     chmod +x /app/entrypoint.sh /app/healthcheck.sh && \
     mkdir -p /app/default-assets
 

--- a/app/package.json
+++ b/app/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "generate:permissions": "node scripts/generate-permission-enum.mjs",
     "test": "vitest run",
+    "test:assets": "node --test scripts/compress-assets.spec.mjs",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",
@@ -13,8 +14,10 @@
     "start:customer": "VITE_APP_MODE=customer vite --config vite.config.customer.js",
     "prebuild:staff": "npm run generate:permissions",
     "build:staff": "VITE_APP_MODE=staff vite build --config vite.config.staff.js",
+    "postbuild:staff": "node scripts/compress-assets.mjs build/staff/assets",
     "prebuild:customer": "npm run generate:permissions",
     "build:customer": "VITE_APP_MODE=customer vite build --config vite.config.customer.js",
+    "postbuild:customer": "node scripts/compress-assets.mjs build/customer/assets",
     "preview:staff": "VITE_APP_MODE=staff vite preview --config vite.config.staff.js",
     "preview:customer": "VITE_APP_MODE=customer vite preview --config vite.config.customer.js"
   },

--- a/app/scripts/compress-assets.mjs
+++ b/app/scripts/compress-assets.mjs
@@ -1,0 +1,49 @@
+import {readdir, readFile, rm, stat, utimes, writeFile} from 'node:fs/promises';
+import {resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {promisify} from 'node:util';
+import {brotliCompress, constants} from 'node:zlib';
+
+const compress = promisify(brotliCompress);
+
+export async function compressAssets(directory) {
+    // Match the immutable asset rule in container/nginx.conf; public files keep their stable URLs.
+    const files = (await readdir(directory, {withFileTypes: true}))
+        .filter((entry) => entry.isFile() && /-[A-Za-z0-9_-]{8}\.(js|css)$/.test(entry.name))
+        .map((entry) => resolve(directory, entry.name));
+    let count = 0;
+    let bytes = 0;
+    let index = 0;
+    // Bound memory use when several large editor and worker bundles are compressed.
+    await Promise.all(Array.from({length: 2}, async () => {
+        while (index < files.length) {
+            const file = files[index++];
+            const original = await readFile(file);
+            const compressed = await compress(original, {
+                params: {
+                    [constants.BROTLI_PARAM_QUALITY]: 11,
+                    [constants.BROTLI_PARAM_MODE]: constants.BROTLI_MODE_TEXT,
+                },
+            });
+            if (compressed.length >= original.length) {
+                await rm(`${file}.br`, {force: true});
+                continue;
+            }
+            const metadata = await stat(file);
+            await writeFile(`${file}.br`, compressed);
+            // Both representations belong to the same build and share Last-Modified.
+            await utimes(`${file}.br`, metadata.atime, metadata.mtime);
+            count += 1;
+            bytes += compressed.length;
+        }
+    }));
+    return {count, bytes};
+}
+
+if (process.argv[1] != null && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+    if (process.argv.length !== 3) {
+        throw new Error('Usage: node scripts/compress-assets.mjs <build-assets-directory>');
+    }
+    const {count, bytes} = await compressAssets(resolve(process.argv[2]));
+    console.log(`Brotli: ${count} assets, ${(bytes / 1_000_000).toFixed(2)} MB precompressed`);
+}

--- a/app/scripts/compress-assets.spec.mjs
+++ b/app/scripts/compress-assets.spec.mjs
@@ -1,0 +1,35 @@
+import {strict as assert} from 'node:assert';
+import {mkdtemp, readFile, readdir, rm, stat, utimes, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {test} from 'node:test';
+import {brotliDecompressSync} from 'node:zlib';
+import {compressAssets} from './compress-assets.mjs';
+
+test('compresses hashed JS/CSS losslessly, preserves originals and excludes stable public files', async (t) => {
+    const directory = await mkdtemp(join(tmpdir(), 'prosuna-assets-'));
+    t.after(() => rm(directory, {recursive: true, force: true}));
+    const source = 'console.log("frontend asset");\n'.repeat(200);
+    const hashed = ['index-Ab12_-34.js', 'editor.worker-Ab12_-34.js', 'index-Ab12_-34.css'];
+    const stable = ['runtime.js', 'index.html', 'font-Ab12_-34.woff2', 'data-Ab12_-34.json'];
+    for (const name of [...hashed, ...stable]) await writeFile(join(directory, name), source);
+    const date = new Date('2025-01-01T00:00:00Z');
+    await utimes(join(directory, hashed[0]), date, date);
+    assert.equal((await compressAssets(directory)).count, hashed.length);
+    for (const name of hashed) {
+        assert.equal(await readFile(join(directory, name), 'utf8'), source);
+        assert.equal(brotliDecompressSync(await readFile(join(directory, `${name}.br`))).toString(), source);
+    }
+    assert.equal((await stat(join(directory, `${hashed[0]}.br`))).mtimeMs, date.getTime());
+    assert.deepEqual((await readdir(directory)).sort(), [...hashed, ...stable, ...hashed.map((name) => `${name}.br`)].sort());
+
+    await writeFile(join(directory, hashed[0]), 'x');
+    await compressAssets(directory);
+    assert.equal((await readdir(directory)).includes(`${hashed[0]}.br`), false);
+});
+
+test('fails the build when the asset directory is missing', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'prosuna-missing-assets-'));
+    await rm(directory, {recursive: true});
+    await assert.rejects(compressAssets(directory), {code: 'ENOENT'});
+});

--- a/app/src/components/code-editor/code-editor.spec.tsx
+++ b/app/src/components/code-editor/code-editor.spec.tsx
@@ -12,8 +12,8 @@ const mocks = vi.hoisted(() => ({
     },
 }));
 
-vi.mock('@monaco-editor/react', () => ({
-    default: (props: {onMount?: (editor: typeof mocks.editor, monaco: unknown) => void}) => {
+vi.mock('./monaco-editor', () => ({
+    MonacoEditor: (props: {onMount?: (editor: typeof mocks.editor, monaco: unknown) => void}) => {
         props.onMount?.(mocks.editor, {
             languages: {},
             typescript: {

--- a/app/src/components/code-editor/code-editor.tsx
+++ b/app/src/components/code-editor/code-editor.tsx
@@ -1,4 +1,5 @@
-import Editor, {type Monaco} from '@monaco-editor/react';
+import {type Monaco} from '@monaco-editor/react';
+import {MonacoEditor} from './monaco-editor';
 import {type editor} from 'monaco-editor';
 import {Box, useTheme} from '@mui/material';
 import React, {useCallback, useEffect, useRef} from 'react';
@@ -158,7 +159,7 @@ export function CodeEditor(props: CodeEditorProps & ActionsProps) {
                 }}
             >
                 {/* React Flow treats descendants of `.nokey` as editors and leaves their keyboard input untouched. */}
-                <Editor
+                <MonacoEditor
                     className="nokey"
                     height={props.height ?? 'max(100vh - 768px, 320px)'}
                     language={props.language ?? 'javascript'}

--- a/app/src/components/code-editor/monaco-editor-loader.spec.ts
+++ b/app/src/components/code-editor/monaco-editor-loader.spec.ts
@@ -1,0 +1,29 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+describe('loadMonacoEditor', () => {
+    beforeEach(() => { vi.resetModules(); });
+    afterEach(() => { vi.doUnmock('./monaco-editor-runtime'); });
+
+    it('defers the runtime import and shares it between concurrent editors', async () => {
+        const initialize = vi.fn(() => ({MonacoEditorImplementation: () => null}));
+        vi.doMock('./monaco-editor-runtime', initialize);
+        const {loadMonacoEditor} = await import('./monaco-editor-loader');
+        expect(initialize).not.toHaveBeenCalled();
+        const first = loadMonacoEditor();
+        const second = loadMonacoEditor();
+        expect(second).toBe(first);
+        expect(await second).toBe(await first);
+        expect(initialize).toHaveBeenCalledTimes(1);
+        expect(loadMonacoEditor()).toBe(first);
+    });
+
+    it('allows another import attempt after a rejected load', async () => {
+        vi.doMock('./monaco-editor-runtime', () => { throw new Error('unavailable'); });
+        const {loadMonacoEditor} = await import('./monaco-editor-loader');
+        await expect(loadMonacoEditor()).rejects.toThrow();
+        const implementation = () => null;
+        vi.doMock('./monaco-editor-runtime', () => ({MonacoEditorImplementation: implementation}));
+        await expect(loadMonacoEditor()).resolves.toEqual({MonacoEditorImplementation: implementation});
+    });
+
+});

--- a/app/src/components/code-editor/monaco-editor-loader.ts
+++ b/app/src/components/code-editor/monaco-editor-loader.ts
@@ -1,0 +1,19 @@
+let editorPromise: Promise<typeof import('./monaco-editor-runtime')> | undefined;
+
+export function isMonacoStylesheetLoadError(error: unknown): boolean {
+    // Keep this guard aligned with the error emitted by Vite's CSS preload helper.
+    return error instanceof Error && error.message.startsWith('Unable to preload CSS for ');
+}
+
+export function loadMonacoEditor(): Promise<typeof import('./monaco-editor-runtime')> {
+    editorPromise ??= import('./monaco-editor-runtime').catch((error: unknown) => {
+        // Vite's preload helper remembers failed CSS URLs and skips them on a second
+        // import. Retain that failure until a page reload instead of mounting an
+        // unstyled editor. Other load failures may be retried without losing inputs.
+        if (!isMonacoStylesheetLoadError(error)) {
+            editorPromise = undefined;
+        }
+        throw error;
+    });
+    return editorPromise;
+}

--- a/app/src/components/code-editor/monaco-editor-runtime.ts
+++ b/app/src/components/code-editor/monaco-editor-runtime.ts
@@ -1,0 +1,5 @@
+import './configure-monaco';
+import Editor from '@monaco-editor/react';
+
+// The local worker and loader configuration must run before any editor mounts.
+export const MonacoEditorImplementation = Editor;

--- a/app/src/components/code-editor/monaco-editor.spec.tsx
+++ b/app/src/components/code-editor/monaco-editor.spec.tsx
@@ -1,0 +1,104 @@
+import {useEffect} from 'react';
+import {act, fireEvent, render, screen} from '@testing-library/react';
+import type {EditorProps} from '@monaco-editor/react';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {MonacoEditor} from './monaco-editor';
+import {loadMonacoEditor} from './monaco-editor-loader';
+
+vi.mock('./monaco-editor-loader', async (importOriginal) => ({
+    ...await importOriginal<typeof import('./monaco-editor-loader')>(),
+    loadMonacoEditor: vi.fn(),
+}));
+
+const mounted = vi.fn();
+function EditorImplementation(props: EditorProps) {
+    useEffect(() => { mounted(); }, []);
+    return <textarea aria-label="Code" value={props.value} readOnly={props.options?.readOnly}
+                     onChange={(event) => props.onChange?.(event.target.value, {} as never)}/>;
+}
+
+describe('MonacoEditor', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.mocked(loadMonacoEditor).mockReset();
+    });
+    afterEach(() => { vi.useRealTimers(); });
+
+    it('uses the latest props after loading and keeps the mounted editor on updates', async () => {
+        let finish!: (value: Awaited<ReturnType<typeof loadMonacoEditor>>) => void;
+        vi.mocked(loadMonacoEditor).mockReturnValue(new Promise((resolve) => { finish = resolve; }));
+        const onChange = vi.fn();
+        const {rerender} = render(<MonacoEditor value="initial" options={{readOnly: false}} onChange={onChange}/>);
+        expect(screen.getByRole('status')).toHaveTextContent('Code-Editor wird geladen');
+        rerender(<MonacoEditor value="updated while loading" options={{readOnly: true}} onChange={onChange}/>);
+        await act(async () => { finish({MonacoEditorImplementation: EditorImplementation as never}); });
+        await act(async () => { await vi.advanceTimersByTimeAsync(499); });
+        expect(screen.getByRole('status')).toBeVisible();
+        expect(mounted).not.toHaveBeenCalled();
+        await act(async () => { await vi.advanceTimersByTimeAsync(1); });
+
+        const editor = screen.getByRole('textbox', {name: 'Code'});
+        expect(editor).toHaveValue('updated while loading');
+        expect(editor).toHaveAttribute('readonly');
+        expect(onChange).not.toHaveBeenCalled();
+        rerender(<MonacoEditor value="updated after loading" options={{readOnly: false}} onChange={onChange}/>);
+        expect(screen.getByRole('textbox', {name: 'Code'})).toBe(editor);
+        expect(editor).toHaveValue('updated after loading');
+        expect(editor).not.toHaveAttribute('readonly');
+        fireEvent.change(editor, {target: {value: 'new input'}});
+        expect(onChange).toHaveBeenCalledWith('new input', expect.anything());
+        expect(mounted).toHaveBeenCalledTimes(1);
+        expect(loadMonacoEditor).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles a failed download locally and retries without changing the value', async () => {
+        vi.mocked(loadMonacoEditor).mockRejectedValueOnce(new Error('missing chunk'))
+            .mockResolvedValueOnce({MonacoEditorImplementation: EditorImplementation as never});
+        const onChange = vi.fn();
+        render(<><input aria-label="Other input" defaultValue="unsaved"/>
+            <MonacoEditor value="existing code" onChange={onChange}/></>);
+        await act(async () => { await vi.advanceTimersByTimeAsync(499); });
+        expect(screen.getByRole('status')).toBeVisible();
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+        await act(async () => { await vi.advanceTimersByTimeAsync(1); });
+        expect(screen.getByRole('alert')).toHaveTextContent('Der Code-Editor konnte nicht geladen werden.');
+        expect(screen.getByRole('textbox', {name: 'Other input'})).toHaveValue('unsaved');
+        fireEvent.click(screen.getByRole('button', {name: 'Erneut versuchen'}));
+        await act(async () => { await vi.advanceTimersByTimeAsync(499); });
+        expect(screen.getByRole('status')).toBeVisible();
+        await act(async () => { await vi.advanceTimersByTimeAsync(1); });
+        expect(screen.getByRole('textbox', {name: 'Code'})).toHaveValue('existing code');
+        expect(onChange).not.toHaveBeenCalled();
+        expect(loadMonacoEditor).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not mount an editor if its view closes while the download is pending', async () => {
+        let finish!: (value: Awaited<ReturnType<typeof loadMonacoEditor>>) => void;
+        vi.mocked(loadMonacoEditor).mockReturnValue(new Promise((resolve) => { finish = resolve; }));
+        const {unmount} = render(<MonacoEditor value="existing code"/>);
+        unmount();
+        await act(async () => { finish({MonacoEditorImplementation: EditorImplementation as never}); });
+        await act(async () => { await vi.advanceTimersByTimeAsync(500); });
+        expect(mounted).not.toHaveBeenCalled();
+    });
+
+    it('does not add a further delay after a slow download', async () => {
+        let finish!: (value: Awaited<ReturnType<typeof loadMonacoEditor>>) => void;
+        vi.mocked(loadMonacoEditor).mockReturnValue(new Promise((resolve) => { finish = resolve; }));
+        render(<MonacoEditor value="existing code"/>);
+        await act(async () => { await vi.advanceTimersByTimeAsync(800); });
+        expect(screen.getByRole('status')).toBeVisible();
+        await act(async () => { finish({MonacoEditorImplementation: EditorImplementation as never}); });
+        expect(screen.getByRole('textbox', {name: 'Code'})).toHaveValue('existing code');
+    });
+
+    it('preserves inputs and explains manual recovery when a stylesheet failure cannot be retried safely', async () => {
+        vi.mocked(loadMonacoEditor).mockRejectedValue(new Error('Unable to preload CSS for /assets/editor-Ab12_-34.css'));
+        render(<><input aria-label="Other input" defaultValue="unsaved"/><MonacoEditor value="existing code"/></>);
+        await act(async () => { await vi.advanceTimersByTimeAsync(500); });
+        expect(screen.getByRole('alert')).toHaveTextContent('Bitte sichern Sie Ihre Eingaben und laden Sie anschließend die Seite neu.');
+        expect(screen.queryByRole('button', {name: 'Erneut versuchen'})).not.toBeInTheDocument();
+        expect(screen.getByRole('textbox', {name: 'Other input'})).toHaveValue('unsaved');
+        expect(mounted).not.toHaveBeenCalled();
+    });
+});

--- a/app/src/components/code-editor/monaco-editor.tsx
+++ b/app/src/components/code-editor/monaco-editor.tsx
@@ -1,0 +1,67 @@
+import {type EditorProps} from '@monaco-editor/react';
+import {Box, Button, CircularProgress, Stack, Typography} from '@mui/material';
+import {useEffect, useState} from 'react';
+import {AlertComponent} from '../alert/alert-component';
+import {isMonacoStylesheetLoadError, loadMonacoEditor} from './monaco-editor-loader';
+import {withAsyncWrapper} from '../../utils/with-async-wrapper';
+
+type EditorImplementation = typeof import('./monaco-editor-runtime')['MonacoEditorImplementation'];
+
+export function MonacoEditor(props: EditorProps) {
+    const [Editor, setEditor] = useState<EditorImplementation>();
+    const [failure, setFailure] = useState<{retryable: boolean}>();
+    const [attempt, setAttempt] = useState(0);
+
+    useEffect(() => {
+        let active = true;
+        setFailure(undefined);
+        withAsyncWrapper({
+            desiredMinRuntime: 500,
+            // Keep the loading state visible for the minimum duration even on fast failures.
+            main: () => Promise.allSettled([loadMonacoEditor()]),
+        }).then(([result]) => {
+            if (result.status === 'rejected') {
+                throw result.reason;
+            }
+            const {MonacoEditorImplementation} = result.value;
+            if (active) {
+                setEditor(() => MonacoEditorImplementation);
+            }
+        }).catch((error: unknown) => {
+            if (active) {
+                setFailure({retryable: !isMonacoStylesheetLoadError(error)});
+            }
+        });
+        return () => {
+            active = false;
+        };
+    }, [attempt]);
+
+    if (Editor != null) {
+        return <Editor {...props}/>;
+    }
+
+    return (
+        <Box sx={{height: props.height, minHeight: 96, display: 'grid', alignItems: 'center'}}>
+            {failure != null ? (
+                <AlertComponent color="error" text="Der Code-Editor konnte nicht geladen werden.">
+                    <Typography variant="body2" sx={{mt: 1}}>
+                        {failure.retryable
+                            ? 'Bitte versuchen Sie es erneut. Falls der Fehler bestehen bleibt, sichern Sie Ihre Eingaben, bevor Sie die Seite neu laden.'
+                            : 'Bitte sichern Sie Ihre Eingaben und laden Sie anschließend die Seite neu.'}
+                    </Typography>
+                    {failure.retryable && (
+                        <Button onClick={() => setAttempt((value) => value + 1)} sx={{mt: 1}}>
+                            Erneut versuchen
+                        </Button>
+                    )}
+                </AlertComponent>
+            ) : (
+                <Stack role="status" aria-busy="true" direction="row" spacing={1.5} sx={{alignItems: 'center', justifyContent: 'center'}}>
+                    <CircularProgress size={20} aria-hidden="true"/>
+                    <Typography variant="body2">Code-Editor wird geladen …</Typography>
+                </Stack>
+            )}
+        </Box>
+    );
+}

--- a/app/src/components/element-editor-structure-tab/structure-tab.spec.tsx
+++ b/app/src/components/element-editor-structure-tab/structure-tab.spec.tsx
@@ -1,0 +1,47 @@
+import {act, render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {expect, it, vi} from 'vitest';
+import {type EditorProps} from '@monaco-editor/react';
+import {StructureTab} from './structure-tab';
+import {type AnyElement} from '../../models/elements/any-element';
+import {ElementType} from '../../data/element-type/element-type';
+
+const mocks = vi.hoisted(() => ({
+    confirm: vi.fn(async () => true),
+    editorProps: {} as EditorProps,
+}));
+
+vi.mock('../../hooks/use-app-dispatch', () => ({useAppDispatch: () => vi.fn()}));
+vi.mock('../../providers/confirm-provider', () => ({useConfirm: () => mocks.confirm}));
+vi.mock('../code-editor/monaco-editor', () => ({
+    MonacoEditor: (props: EditorProps) => {
+        mocks.editorProps = props;
+        return null;
+    },
+}));
+
+it('enables manual editing only after Monaco mounts while keeping the structure download available', async () => {
+    const user = userEvent.setup();
+    const element = {id: 'field', type: ElementType.Text, label: 'Name'} as AnyElement;
+    const changed = {...element, label: 'Neuer Name'};
+    const onChange = vi.fn();
+    render(<StructureTab elementModel={element} editable onChange={onChange}/>);
+
+    const toggle = screen.getByRole('switch', {name: 'Struktur manuell überschreiben'});
+    expect(toggle).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Struktur anwenden'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Elementstruktur herunterladen'})).toBeEnabled();
+    expect(mocks.confirm).not.toHaveBeenCalled();
+
+    act(() => {
+        mocks.editorProps.onMount?.({getValue: () => JSON.stringify(changed)} as never, {} as never);
+    });
+    expect(toggle).toBeEnabled();
+    await user.click(toggle);
+    expect(mocks.confirm).toHaveBeenCalledTimes(1);
+    expect(toggle).toBeChecked();
+    expect(mocks.editorProps.options?.readOnly).toBe(false);
+    await user.click(screen.getByRole('button', {name: 'Struktur anwenden'}));
+    expect(onChange).toHaveBeenCalledWith(changed);
+    expect(toggle).not.toBeChecked();
+});

--- a/app/src/components/element-editor-structure-tab/structure-tab.tsx
+++ b/app/src/components/element-editor-structure-tab/structure-tab.tsx
@@ -1,4 +1,5 @@
-import Editor from '@monaco-editor/react';
+import {MonacoEditor} from '../code-editor/monaco-editor';
+import {type editor} from 'monaco-editor';
 import {Box, Button, FormControlLabel, Switch, useTheme} from '@mui/material';
 import React, {type ChangeEvent, useCallback, useRef, useState} from 'react';
 import {type StructureTabProps} from './structure-tab-props';
@@ -20,12 +21,15 @@ export function StructureTab<T extends AnyElement>(props: StructureTabProps<T>) 
     const dispatch = useAppDispatch();
     const showConfirm = useConfirm();
 
-    const editorRef = useRef<any>(undefined);
+    const editorRef = useRef<editor.IStandaloneCodeEditor>(undefined);
+    // Editing actions need a mounted editor; downloading the runtime alone is not enough.
+    const [isEditorReady, setIsEditorReady] = useState(false);
     const [editable, setEditable] = useState(false);
 
-    const handleEditorDidMount = useCallback((editor: any, _: any) => {
+    const handleEditorDidMount = useCallback((editor: editor.IStandaloneCodeEditor) => {
         editorRef.current = editor;
-    }, [editorRef]);
+        setIsEditorReady(true);
+    }, []);
 
     const handleToggleEditable = async (event: ChangeEvent<HTMLInputElement>): Promise<void> => {
         if (event.target.checked) {
@@ -111,6 +115,7 @@ export function StructureTab<T extends AnyElement>(props: StructureTabProps<T>) 
                 >
                     <FormControlLabel
                         control={<Switch
+                            disabled={!isEditorReady}
                             checked={editable}
                             onChange={handleToggleEditable}
                         />}
@@ -175,7 +180,7 @@ export function StructureTab<T extends AnyElement>(props: StructureTabProps<T>) 
                     borderRadius: 1,
                 }}
             >
-                <Editor
+                <MonacoEditor
                     height="calc(100vh - 400px)"
                     defaultLanguage="json"
                     theme={theme.palette.mode === 'dark' ? 'vs-dark' : 'light'}

--- a/app/src/index.customer.tsx
+++ b/app/src/index.customer.tsx
@@ -7,7 +7,6 @@ import {createRoutesFromChildren, matchRoutes, useLocation, useNavigationType} f
 import {createRoot} from 'react-dom/client';
 import {isStringNotNullOrEmpty} from './utils/string-utils';
 import {CustomerShellRouter} from './shells/customer/customer-shell-router';
-import './components/code-editor/configure-monaco';
 
 
 const rootElement = document.getElementById('root')!;

--- a/app/src/index.staff.tsx
+++ b/app/src/index.staff.tsx
@@ -9,7 +9,6 @@ import {createRoutesFromChildren, matchRoutes, useLocation, useNavigationType} f
 import {createRoot} from 'react-dom/client';
 import {isStringNotNullOrEmpty} from './utils/string-utils';
 import {StaffShellRouter} from './shells/staff/staff-shell-router';
-import './components/code-editor/configure-monaco';
 
 const rootElement = document.getElementById('root')!;
 const root = createRoot(rootElement);

--- a/app/src/modules/process/pages/details/components/process-flow-editor/process-flow-editor.spec.tsx
+++ b/app/src/modules/process/pages/details/components/process-flow-editor/process-flow-editor.spec.tsx
@@ -1,0 +1,86 @@
+import {type ComponentProps, type PropsWithChildren, useState} from 'react';
+import {act, render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {expect, it, vi} from 'vitest';
+import {ElkLoadError} from '../../../../../../utils/elk-loader';
+import {ProcessFlowEditor} from './process-flow-editor';
+import {type FlowNode, layoutElements} from './utils/layout-utils';
+
+const flow = vi.hoisted(() => ({
+    nodes: [] as FlowNode[],
+    getNodes: vi.fn((): FlowNode[] => flow.nodes),
+    setViewport: vi.fn(async () => true),
+}));
+
+vi.mock('./utils/layout-utils', async (importOriginal) => ({
+    ...await importOriginal<typeof import('./utils/layout-utils')>(),
+    layoutElements: vi.fn(),
+}));
+vi.mock('./process-flow-editor-node', () => ({ProcessFlowEditorNode: () => null}));
+vi.mock('./process-flow-editor-edge', () => ({ProcessFlowEditorEdge: () => null}));
+vi.mock('../../../../components/process-node-provider-details', () => ({ProcessNodeProviderDetailsDialog: () => null}));
+vi.mock('../../../../dialogs/process-instance-event-dialog', () => ({ProcessInstanceEventDialog: () => null}));
+vi.mock('@xyflow/react', async (importOriginal) => ({
+    ...await importOriginal<typeof import('@xyflow/react')>(),
+    ReactFlow: ({children}: PropsWithChildren) => <div aria-label="Prozessfluss">{children}</div>,
+    Panel: ({children}: PropsWithChildren) => children,
+    Controls: () => null,
+    Background: () => null,
+    MiniMap: () => null,
+    useNodesState: () => {
+        const [nodes, setNodes] = useState<FlowNode[]>([]);
+        flow.nodes = nodes;
+        return [nodes, setNodes, vi.fn()];
+    },
+    useNodesInitialized: () => flow.nodes.length > 0,
+    useReactFlow: () => ({getNodes: flow.getNodes, setViewport: flow.setViewport}),
+    useStore: (selector: (state: unknown) => unknown) => selector({domNode: {clientWidth: 1280}, transform: [0, 0, 1]}),
+}));
+
+it('retries a failed runtime download and restores the initial diagram viewport without discarding inputs', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const node = {id: 1, processNodeDefinitionKey: 'test', processNodeDefinitionVersion: 1};
+    const provider = {key: 'test', majorVersion: 1, type: 'action'};
+    const result = {
+        flowNodes: [{id: '1', position: {x: 32, y: 144}, width: 420, height: 200, data: {graphNode: {node, provider}}}],
+        flowEdges: [],
+    } as unknown as Awaited<ReturnType<typeof layoutElements>>;
+    vi.mocked(layoutElements).mockRejectedValueOnce(new ElkLoadError(new Error('offline'))).mockResolvedValue(result);
+    const props = {
+        editable: false,
+        processFlow: {definition: {id: 1}, version: {processVersion: 1}, nodes: [node], edges: []},
+        nodeProviders: [provider], runtimeData: null, onReloadRuntimeData: vi.fn(),
+        nodeProblems: [], showNodeProblemsForNodes: {},
+    } as unknown as ComponentProps<typeof ProcessFlowEditor>;
+    render(<><input aria-label="Ungespeicherte Notiz" defaultValue="Entwurf"/><ProcessFlowEditor {...props}/></>);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Die Darstellung des Prozessflusses konnte nicht geladen werden.');
+    expect(flow.setViewport).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByRole('button', {name: 'Erneut versuchen'}));
+
+    await waitFor(() => expect(flow.setViewport).toHaveBeenCalledWith({x: 398, y: -96, zoom: 1}, {duration: 0}));
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'Ungespeicherte Notiz'})).toHaveValue('Entwurf');
+    expect(flow.nodes.map((item) => item.id)).toEqual(['1']);
+});
+
+it('ignores a pending layout after switching to a process whose providers are unavailable', async () => {
+    let finish!: (result: Awaited<ReturnType<typeof layoutElements>>) => void;
+    vi.mocked(layoutElements).mockReset().mockReturnValue(new Promise((resolve) => { finish = resolve; }));
+    const props = {
+        editable: false,
+        processFlow: {definition: {id: 1}, version: {processVersion: 1}, nodes: [{id: 1, processNodeDefinitionKey: 'test', processNodeDefinitionVersion: 1}], edges: []},
+        nodeProviders: [{key: 'test', majorVersion: 1}], runtimeData: null, onReloadRuntimeData: vi.fn(),
+        nodeProblems: [], showNodeProblemsForNodes: {},
+    } as unknown as ComponentProps<typeof ProcessFlowEditor>;
+    const {rerender} = render(<ProcessFlowEditor {...props}/>);
+    await waitFor(() => expect(layoutElements).toHaveBeenCalledTimes(1));
+
+    rerender(<ProcessFlowEditor {...props} nodeProviders={[]}/>);
+    await act(async () => {
+        finish({flowNodes: [{id: 'obsolete', position: {x: 0, y: 0}, data: {}}], flowEdges: []} as unknown as Awaited<ReturnType<typeof layoutElements>>);
+    });
+
+    expect(flow.nodes).toEqual([]);
+    expect(flow.setViewport).not.toHaveBeenCalled();
+});

--- a/app/src/modules/process/pages/details/components/process-flow-editor/process-flow-editor.tsx
+++ b/app/src/modules/process/pages/details/components/process-flow-editor/process-flow-editor.tsx
@@ -37,7 +37,8 @@ import {
     layoutElements,
     ProcessFlowLayoutError,
 } from './utils/layout-utils';
-import {Box, Tooltip, useTheme} from '@mui/material';
+import {Box, Button, Tooltip, useTheme} from '@mui/material';
+import {ElkLoadError} from '../../../../../../utils/elk-loader';
 import {alpha} from '@mui/material/styles';
 import {type ProcessInstanceEntity} from '../../../../entities/process-instance-entity';
 import {type ProcessInstanceTaskEntity} from '../../../../entities/process-instance-task-entity';
@@ -278,6 +279,7 @@ interface FlowViewport {
 }
 
 interface ProcessFlowEditorLayoutError {
+    retryable?: boolean;
     message: string;
     details: string[];
     causeHint: string;
@@ -321,7 +323,7 @@ function ProcessFlowEditorCanvasTriggerLaneHeader(props: ProcessFlowEditorCanvas
     );
 }
 
-function ProcessFlowEditorLayoutErrorPanel(props: {layoutError: ProcessFlowEditorLayoutError}): ReactNode {
+function ProcessFlowEditorLayoutErrorPanel(props: {layoutError: ProcessFlowEditorLayoutError; onRetry: () => void}): ReactNode {
     const visibleDetails = props.layoutError.details.slice(0, 4);
     const hiddenDetailsCount = props.layoutError.details.length - visibleDetails.length;
 
@@ -384,12 +386,27 @@ function ProcessFlowEditorLayoutErrorPanel(props: {layoutError: ProcessFlowEdito
                     <strong>Wiederherstellung:</strong><br/>
                     {props.layoutError.recoveryHint}
                 </Box>
+                {props.layoutError.retryable && (
+                    <Button onClick={props.onRetry} sx={{mt: 1}}>
+                        Erneut versuchen
+                    </Button>
+                )}
             </AlertComponent>
         </Panel>
     );
 }
 
 function createLayoutErrorState(error: unknown): ProcessFlowEditorLayoutError {
+    if (error instanceof ElkLoadError) {
+        return {
+            message: 'Die Darstellung des Prozessflusses konnte nicht geladen werden.',
+            details: [],
+            causeHint: 'Ein benötigter Bestandteil der Anwendung ist derzeit nicht verfügbar.',
+            recoveryHint: 'Bitte versuchen Sie es erneut. Falls der Fehler bestehen bleibt, sichern Sie Ihre Eingaben, bevor Sie die Seite neu laden.',
+            retryable: true,
+        };
+    }
+
     if (error instanceof ProcessFlowLayoutError) {
         return {
             message: error.message,
@@ -470,6 +487,7 @@ export function ProcessFlowEditor(props: ProcessFlowEditorProps): ReactNode {
     const [isInitialViewportReady, setIsInitialViewportReady] = useState<boolean>(processFlow.nodes.length === 0);
     const [canvasTriggerLaneHeaderPosition, setCanvasTriggerLaneHeaderPosition] = useState<CanvasTriggerLaneHeaderPosition | null>(null);
     const [layoutError, setLayoutError] = useState<ProcessFlowEditorLayoutError | null>(null);
+    const [layoutAttempt, setLayoutAttempt] = useState(0);
     const [providerDetailsDialogProvider, setProviderDetailsDialogProvider] = useState<ProcessNodeProvider | null>(null);
     const [eventDialogTarget, setEventDialogTarget] = useState<ProcessFlowEditorEventDialogTarget | null>(null);
 
@@ -709,7 +727,13 @@ export function ProcessFlowEditor(props: ProcessFlowEditorProps): ReactNode {
         setNeedsMeasuredLayout(!hasMeasurementsForAllNodes);
 
         resolveInitialViewportDecision();
-    }, [getNodes, hasAllNodeProviders, layoutNodes, processFlow.nodes, resolveInitialViewportDecision]);
+
+        return () => {
+            // A pending runtime download must not restore an obsolete graph after a
+            // switch to a process with missing providers, or after the editor closes.
+            layoutRequestIdRef.current += 1;
+        };
+    }, [getNodes, hasAllNodeProviders, layoutNodes, processFlow.nodes, resolveInitialViewportDecision, layoutAttempt]);
 
     useEffect(() => {
         if (!hasAllNodeProviders || !needsMeasuredLayout || !nodesInitialized) {
@@ -878,6 +902,12 @@ export function ProcessFlowEditor(props: ProcessFlowEditorProps): ReactNode {
                         layoutError != null &&
                         <ProcessFlowEditorLayoutErrorPanel
                             layoutError={layoutError}
+                            onRetry={() => {
+                                setLayoutError(null);
+                                // Re-enter measurement and centering, not only the ELK layout call.
+                                resetInitialViewportState(!hasProcessNodes);
+                                setLayoutAttempt((value) => value + 1);
+                            }}
                         />
                     }
                     {

--- a/app/src/modules/process/pages/details/components/process-flow-editor/utils/layout-utils.ts
+++ b/app/src/modules/process/pages/details/components/process-flow-editor/utils/layout-utils.ts
@@ -1,4 +1,5 @@
-import ELK, {type ElkEdgeSection, type ElkExtendedEdge, type ElkNode, type ElkPoint, type ElkPort} from 'elkjs/lib/elk.bundled.js';
+import {type ElkEdgeSection, type ElkExtendedEdge, type ElkNode, type ElkPoint, type ElkPort} from 'elkjs/lib/elk.bundled.js';
+import {createElkLoader} from '../../../../../../../utils/elk-loader';
 import {type Edge as ReactFlowEdge, MarkerType, type Node as ReactFlowNode} from '@xyflow/react';
 import {type ProcessDefinitionEdgeEntity} from '../../../../../entities/process-definition-edge-entity';
 import {type ProcessNodeEntity} from '../../../../../entities/process-node-entity';
@@ -20,7 +21,7 @@ import {
     type ProcessFlowGraphNode,
 } from './process-flow-graph-utils';
 
-const elk = new ELK();
+const getElk = createElkLoader();
 
 const ELK_TARGET_PORT_KEY = '__target__';
 const INCLUDED_PORTS_IN_MIN_WIDTH = 2;
@@ -122,6 +123,7 @@ export async function layoutElements(
     validateProcessFlowGraph(graph);
     const layoutMetaByNodeId = createLayoutMeta(graph, nodeMeasurements);
     const elkGraph = createElkGraph(graph, layoutMetaByNodeId);
+    const elk = await getElk();
     const laidOutGraph = await elk.layout(elkGraph);
     const resolvedLayoutNodes = createResolvedLayoutNodeMap(laidOutGraph, layoutMetaByNodeId);
 

--- a/app/src/modules/system/pages/organization-chart/organization-chart-flow.spec.tsx
+++ b/app/src/modules/system/pages/organization-chart/organization-chart-flow.spec.tsx
@@ -1,0 +1,71 @@
+import {type PropsWithChildren} from 'react';
+import {act, render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {type ElkNode} from 'elkjs/lib/elk.bundled.js';
+import {ElkLoadError} from '../../../../utils/elk-loader';
+import {OrganizationChartFlow} from './organization-chart-flow';
+import {type OrganizationChartDepartmentItem} from './organization-chart-types';
+
+const {getElk, fitView} = vi.hoisted(() => ({getElk: vi.fn(), fitView: vi.fn()}));
+
+vi.mock('../../../../utils/elk-loader', async (importOriginal) => ({
+    ...await importOriginal<typeof import('../../../../utils/elk-loader')>(),
+    createElkLoader: () => getElk,
+}));
+vi.mock('@xyflow/react', async (importOriginal) => ({
+    ...await importOriginal<typeof import('@xyflow/react')>(),
+    ReactFlowProvider: ({children}: PropsWithChildren) => children,
+    ReactFlow: ({nodes}: {nodes: {id: string; data: {item: {name: string}}}[]}) => (
+        <ul aria-label="Organigramm">{nodes.map((node) => <li key={node.id}>{node.data.item.name}</li>)}</ul>
+    ),
+    useReactFlow: () => ({fitView}),
+}));
+
+function department(id: number, name: string): OrganizationChartDepartmentItem {
+    return {
+        id, name, depth: 0, created: '', updated: '', color: '#123456',
+        children: [], members: [], canReadDetails: false, canReadMemberships: false,
+    };
+}
+
+const elk = {
+    layout: async (graph: ElkNode) => ({
+        ...graph,
+        children: graph.children?.map((node) => ({...node, x: 10, y: 20})),
+    }),
+};
+
+describe('OrganizationChartFlow loading', () => {
+    beforeEach(() => {
+        getElk.mockReset();
+        vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    });
+
+    it('shows a local download error and restores the diagram after retry', async () => {
+        getElk.mockRejectedValueOnce(new ElkLoadError(new Error('offline'))).mockResolvedValue(elk);
+        render(<OrganizationChartFlow view="departments" rootDepartments={[department(1, 'Bürgerbüro')]} teams={[]} canReadUsers={false}/>);
+
+        expect(await screen.findByRole('alert')).toHaveTextContent('Die Darstellung des Organigramms konnte nicht geladen werden.');
+        await userEvent.click(screen.getByRole('button', {name: 'Erneut versuchen'}));
+
+        expect(await screen.findByText('Bürgerbüro')).toBeVisible();
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+        expect(getElk).toHaveBeenCalledTimes(2);
+    });
+
+    it('ignores an obsolete download failure after the input has changed', async () => {
+        let rejectFirst!: (error: unknown) => void;
+        getElk.mockReturnValueOnce(new Promise((_, reject) => { rejectFirst = reject; })).mockResolvedValue(elk);
+        const {rerender} = render(<OrganizationChartFlow view="departments" rootDepartments={[department(1, 'Alt')]} teams={[]} canReadUsers={false}/>);
+        await waitFor(() => expect(getElk).toHaveBeenCalledTimes(1));
+
+        rerender(<OrganizationChartFlow view="departments" rootDepartments={[department(2, 'Neu')]} teams={[]} canReadUsers={false}/>);
+        expect(await screen.findByText('Neu')).toBeVisible();
+        await act(async () => { rejectFirst(new ElkLoadError(new Error('offline'))); });
+
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+        expect(screen.getByText('Neu')).toBeVisible();
+        expect(screen.queryByText('Alt')).not.toBeInTheDocument();
+    });
+});

--- a/app/src/modules/system/pages/organization-chart/organization-chart-flow.tsx
+++ b/app/src/modules/system/pages/organization-chart/organization-chart-flow.tsx
@@ -1,4 +1,6 @@
-import ELK, {type ElkNode} from 'elkjs/lib/elk.bundled.js';
+import {type ElkNode} from 'elkjs/lib/elk.bundled.js';
+import {createElkLoader, ElkLoadError} from '../../../../utils/elk-loader';
+import {AlertComponent} from '../../../../components/alert/alert-component';
 import {
     Background,
     BackgroundVariant,
@@ -128,7 +130,7 @@ interface OrganizationChartMemberListProps {
     compact?: boolean;
 }
 
-const elk = new ELK();
+const getElk = createElkLoader();
 const FLOW_NODE_TYPE = 'organization-chart-node';
 const FLOW_NODE_WIDTH = 420;
 const FLOW_NODE_MIN_HEIGHT = 195;
@@ -313,10 +315,13 @@ function OrganizationChartFlowCanvas(props: OrganizationChartFlowCanvasProps): R
         groups: [],
     });
     const [isLayoutReady, setIsLayoutReady] = useState(false);
+    const [layoutError, setLayoutError] = useState<string>();
+    const [layoutAttempt, setLayoutAttempt] = useState(0);
 
     useEffect(() => {
         let isActive = true;
         setIsLayoutReady(false);
+        setLayoutError(undefined);
 
         createLayout(view, rootDepartments, teams, canReadUsers)
             .then((nextLayout) => {
@@ -338,13 +343,16 @@ function OrganizationChartFlowCanvas(props: OrganizationChartFlowCanvasProps): R
                     edges: [],
                     groups: [],
                 });
+                setLayoutError(error instanceof ElkLoadError
+                    ? 'Die Darstellung des Organigramms konnte nicht geladen werden.'
+                    : 'Das Organigramm konnte nicht angeordnet werden.');
                 setIsLayoutReady(true);
             });
 
         return () => {
             isActive = false;
         };
-    }, [canReadUsers, rootDepartments, teams, view]);
+    }, [canReadUsers, rootDepartments, teams, view, layoutAttempt]);
 
     useEffect(() => {
         if (!isLayoutReady || layout.nodes.length === 0) {
@@ -359,6 +367,16 @@ function OrganizationChartFlowCanvas(props: OrganizationChartFlowCanvasProps): R
             cancelAnimationFrame(frameHandle);
         };
     }, [fitView, isLayoutReady, layout.nodes.length, view]);
+
+    if (layoutError != null) {
+        return (
+            <AlertComponent color="error" text={layoutError} sx={{m: 2}}>
+                <Button onClick={() => setLayoutAttempt((value) => value + 1)}>
+                    Erneut versuchen
+                </Button>
+            </AlertComponent>
+        );
+    }
 
     return (
         <ReactFlow
@@ -1183,6 +1201,7 @@ async function createPositionedDepartmentTreeLayout(
             targets: [edge.target],
         })),
     };
+    const elk = await getElk();
     const laidOutGraph = await elk.layout(elkGraph);
     const positionsByNodeId = new Map((laidOutGraph.children ?? []).map((child) => [
         child.id,

--- a/app/src/utils/elk-loader.integration.spec.ts
+++ b/app/src/utils/elk-loader.integration.spec.ts
@@ -1,0 +1,21 @@
+import {expect, it} from 'vitest';
+import ELK, {type ElkNode} from 'elkjs/lib/elk.bundled.js';
+import {createElkLoader} from './elk-loader';
+
+it('preserves layered layout results with the real dynamically imported ELK runtime', async () => {
+    const graph: ElkNode = {
+        id: 'root',
+        layoutOptions: {'elk.algorithm': 'layered', 'elk.direction': 'DOWN'},
+        children: [{id: 'a', width: 100, height: 50}, {id: 'b', width: 100, height: 50}],
+        edges: [{id: 'a-b', sources: ['a'], targets: ['b']}],
+    };
+    const eager = new ELK();
+    const lazy = await createElkLoader()();
+    const expected = await eager.layout(structuredClone(graph));
+    const actual = await lazy.layout(structuredClone(graph));
+    expect(actual.children).toMatchObject(expected.children!.map(({id, x, y, width, height}) => ({id, x, y, width, height})));
+    const edgeGeometry = (result: ElkNode) => result.edges![0].sections!.map(({startPoint, endPoint, bendPoints}) => ({startPoint, endPoint, bendPoints}));
+    expect(edgeGeometry(actual)).toEqual(edgeGeometry(expected));
+    expect(actual.children![1].y).toBeGreaterThan(actual.children![0].y!);
+    expect(actual.edges![0].sections).toHaveLength(1);
+});

--- a/app/src/utils/elk-loader.spec.ts
+++ b/app/src/utils/elk-loader.spec.ts
@@ -1,0 +1,67 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+describe('createElkLoader', () => {
+    beforeEach(() => { vi.resetModules(); });
+    afterEach(() => {
+        vi.doUnmock('elkjs/lib/elk.bundled.js');
+        vi.useRealTimers();
+    });
+
+    it('loads on demand, shares concurrent initialization and keeps diagram instances separate', async () => {
+        const createInstance = vi.fn();
+        const imported = vi.fn(() => ({default: class {
+            constructor() { createInstance(); }
+        }}));
+        vi.doMock('elkjs/lib/elk.bundled.js', imported);
+        const {createElkLoader} = await import('./elk-loader');
+        const process = createElkLoader();
+        const organization = createElkLoader();
+        expect(imported).not.toHaveBeenCalled();
+        const first = process();
+        expect(process()).toBe(first);
+        const instance = await first;
+        expect(await process()).toBe(instance);
+        expect(await organization()).not.toBe(instance);
+        expect(imported).toHaveBeenCalledTimes(1);
+        expect(createInstance).toHaveBeenCalledTimes(2);
+    });
+
+    it('wraps load errors and permits a later retry', async () => {
+        vi.doMock('elkjs/lib/elk.bundled.js', () => { throw new Error('unavailable'); });
+        const {createElkLoader, ElkLoadError} = await import('./elk-loader');
+        const getElk = createElkLoader();
+        await expect(getElk()).rejects.toBeInstanceOf(ElkLoadError);
+        vi.doMock('elkjs/lib/elk.bundled.js', () => ({default: class {}}));
+        await expect(getElk()).resolves.toBeDefined();
+    });
+
+    it('keeps initial loading visible for 500 ms and reuses the ready instance without a further delay', async () => {
+        vi.useFakeTimers();
+        vi.doMock('elkjs/lib/elk.bundled.js', () => ({default: class {}}));
+        const {createElkLoader} = await import('./elk-loader');
+        const getElk = createElkLoader();
+        const completed = vi.fn();
+        const first = getElk();
+        void first.then(completed);
+        await vi.advanceTimersByTimeAsync(499);
+        expect(completed).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(1);
+        const instance = await first;
+        expect(completed).toHaveBeenCalledWith(instance);
+        expect(await getElk()).toBe(instance);
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('also holds a fast load error until the minimum duration has elapsed', async () => {
+        vi.useFakeTimers();
+        vi.doMock('elkjs/lib/elk.bundled.js', () => { throw new Error('offline'); });
+        const {createElkLoader, ElkLoadError} = await import('./elk-loader');
+        const failed = vi.fn();
+        const first = createElkLoader()().catch(failed);
+        await vi.advanceTimersByTimeAsync(499);
+        expect(failed).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(1);
+        await first;
+        expect(failed).toHaveBeenCalledWith(expect.any(ElkLoadError));
+    });
+});

--- a/app/src/utils/elk-loader.ts
+++ b/app/src/utils/elk-loader.ts
@@ -1,0 +1,35 @@
+import {type ELK} from 'elkjs/lib/elk.bundled.js';
+import {withAsyncWrapper} from './with-async-wrapper';
+
+export class ElkLoadError extends Error {
+    constructor(cause: unknown) {
+        super('Could not load the diagram layout engine', {cause});
+        this.name = 'ElkLoadError';
+    }
+}
+
+// Keep each diagram's own ELK instance, but share its initialization between
+// concurrent layout requests. A failed download must not poison later attempts.
+export function createElkLoader(): () => Promise<ELK> {
+    let instancePromise: Promise<ELK> | undefined;
+    return () => {
+        instancePromise ??= withAsyncWrapper({
+            desiredMinRuntime: 500,
+            // Delay initial loading and retries, including failures, but not subsequent layouts.
+            main: () => Promise.allSettled([
+                import('elkjs/lib/elk.bundled.js').then(({default: ELK}) => new ELK()),
+            ]),
+        })
+            .then(([result]) => {
+                if (result.status === 'rejected') {
+                    throw result.reason;
+                }
+                return result.value;
+            })
+            .catch((error: unknown) => {
+                instancePromise = undefined;
+                throw new ElkLoadError(error);
+            });
+        return instancePromise;
+    };
+}

--- a/container/Containerfile.nginx-test
+++ b/container/Containerfile.nginx-test
@@ -1,0 +1,7 @@
+FROM alpine:3.23
+
+# Use the same Nginx packages as the application image; Node generates test assets.
+RUN apk add --no-cache nginx nginx-mod-http-brotli nodejs curl
+COPY container/nginx.conf container/test-nginx.sh /tests/
+COPY app/scripts/compress-assets.mjs /tests/compress-assets.mjs
+CMD ["sh", "/tests/test-nginx.sh"]

--- a/container/nginx.conf
+++ b/container/nginx.conf
@@ -8,7 +8,26 @@ server {
     index index.html;
 
     gzip       on;
+    gzip_comp_level 6;
+    gzip_vary on;
     gzip_types text/css application/javascript application/json image/svg+xml;
+
+    # Only Vite's content-hashed JavaScript and CSS are immutable. Missing chunks
+    # must return 404 instead of the SPA HTML, including after a deployment.
+    location ~ "^/(staff/)?assets/[^/]+-[A-Za-z0-9_-]{8}\.(js|css)$" {
+        try_files $uri =404;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
+    location /assets/ {
+        try_files $uri =404;
+        add_header Cache-Control "no-cache";
+    }
+
+    location /staff/assets/ {
+        try_files $uri =404;
+        add_header Cache-Control "no-cache";
+    }
 
     location = /sbom/manifest.json {
         try_files $uri =404;

--- a/container/nginx.conf
+++ b/container/nginx.conf
@@ -16,6 +16,9 @@ server {
     # must return 404 instead of the SPA HTML, including after a deployment.
     location ~ "^/(staff/)?assets/[^/]+-[A-Za-z0-9_-]{8}\.(js|css)$" {
         try_files $uri =404;
+        # Keep the original URI/MIME type and negotiate the build-generated .br sidecar.
+        # "on" honors Accept-Encoding; "always" would break clients without Brotli.
+        brotli_static on;
         add_header Cache-Control "public, max-age=31536000, immutable";
     }
 

--- a/container/test-nginx.sh
+++ b/container/test-nginx.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+# Run only in a disposable nginx container; this creates fixtures in /app/www.
+set -eu
+
+trap 'nginx -s quit >/dev/null 2>&1 || true' EXIT
+mkdir -p /app/www/assets/fonts /app/www/staff/assets /app/www/sbom
+cp /tests/nginx.conf /etc/nginx/http.d/default.conf
+printf 'customer entry' > /app/www/index.html
+printf 'staff entry' > /app/www/staff/index.html
+printf '{}' > /app/www/sbom/manifest.json
+printf 'unversioned' > /app/www/assets/runtime.js
+printf 'font' > /app/www/assets/fonts/public-sans.woff2
+printf 'not a hashed asset' > /app/www/assets/test-12345678Xjs
+awk 'BEGIN {for (i = 0; i < 1000; i++) print "console.log(\"compression fixture\");"}' > /app/www/assets/index-Ab12_-34.js
+cp /app/www/assets/index-Ab12_-34.js /app/www/staff/assets/index-Ab12_-34.js
+awk 'BEGIN {for (i = 0; i < 1000; i++) print ".fixture { color: black; }"}' > /app/www/assets/index-Ab12_-34.css
+node /tests/compress-assets.mjs /app/www/assets
+node /tests/compress-assets.mjs /app/www/staff/assets
+cp /app/www/assets/index-Ab12_-34.js /app/www/assets/plain-Ab12_-34.js
+cp /app/www/assets/index-Ab12_-34.js.br /app/www/assets/orphan-Ab12_-34.js.br
+nginx -t
+nginx
+
+fetch() {
+    curl --silent --show-error --location --max-time 10 --dump-header /tmp/headers --output /tmp/body "$@"
+}
+
+for asset_path in /assets/index-Ab12_-34.js /staff/assets/index-Ab12_-34.js /assets/index-Ab12_-34.css; do
+    fetch "http://127.0.0.1:8080$asset_path"
+    grep -q 'HTTP/1.1 200' /tmp/headers
+    grep -q 'Cache-Control: public, max-age=31536000, immutable' /tmp/headers
+done
+
+# Cached variants need distinct validators and must keep Vary even on a 304 response.
+fetch --header='Accept-Encoding: br' http://127.0.0.1:8080/assets/index-Ab12_-34.js
+brotli_etag=$(awk 'tolower($1) == "etag:" {gsub("\r", "", $2); print $2}' /tmp/headers)
+test -n "$brotli_etag"
+fetch --head --header='Accept-Encoding: br' http://127.0.0.1:8080/assets/index-Ab12_-34.js
+grep -q 'HTTP/1.1 200' /tmp/headers
+grep -q 'Content-Encoding: br' /tmp/headers
+grep -q 'Vary: Accept-Encoding' /tmp/headers
+fetch --header='Accept-Encoding: br' --header="If-None-Match: $brotli_etag" http://127.0.0.1:8080/assets/index-Ab12_-34.js
+grep -q 'HTTP/1.1 304' /tmp/headers
+grep -q 'Vary: Accept-Encoding' /tmp/headers
+grep -q 'Cache-Control: public, max-age=31536000, immutable' /tmp/headers
+fetch --header='Accept-Encoding: identity' --header="If-None-Match: $brotli_etag" http://127.0.0.1:8080/assets/index-Ab12_-34.js
+grep -q 'HTTP/1.1 200' /tmp/headers
+cmp /tmp/body /app/www/assets/index-Ab12_-34.js
+
+fetch --header='Accept-Encoding: gzip' http://127.0.0.1:8080/assets/index-Ab12_-34.js
+grep -q 'Content-Encoding: gzip' /tmp/headers
+grep -q 'Vary: Accept-Encoding' /tmp/headers
+gzip -dc /tmp/body > /tmp/decoded
+cmp /tmp/decoded /app/www/assets/index-Ab12_-34.js
+
+for asset_path in /assets/index-Ab12_-34.js /staff/assets/index-Ab12_-34.js /assets/index-Ab12_-34.css; do
+    for encoding in br 'gzip, br'; do
+        fetch --header="Accept-Encoding: $encoding" "http://127.0.0.1:8080$asset_path"
+        grep -q 'HTTP/1.1 200' /tmp/headers
+        grep -q 'Content-Encoding: br' /tmp/headers
+        grep -q 'Vary: Accept-Encoding' /tmp/headers
+        grep -q 'Cache-Control: public, max-age=31536000, immutable' /tmp/headers
+        case "$asset_path" in
+            *.css) grep -q 'Content-Type: text/css' /tmp/headers ;;
+            *.js) grep -q 'Content-Type: application/javascript' /tmp/headers ;;
+        esac
+        node -e 'const fs = require("node:fs"); fs.writeFileSync("/tmp/decoded", require("node:zlib").brotliDecompressSync(fs.readFileSync("/tmp/body")));'
+        cmp /tmp/decoded "/app/www$asset_path"
+    done
+    for encoding in identity 'br;q=0'; do
+        fetch --header="Accept-Encoding: $encoding" "http://127.0.0.1:8080$asset_path"
+        if grep -q 'Content-Encoding:' /tmp/headers; then exit 1; fi
+        grep -q 'Vary: Accept-Encoding' /tmp/headers
+        cmp /tmp/body "/app/www$asset_path"
+    done
+done
+
+fetch --header='Accept-Encoding: gzip, br;q=0' http://127.0.0.1:8080/assets/index-Ab12_-34.js
+grep -q 'Content-Encoding: gzip' /tmp/headers
+gzip -dc /tmp/body > /tmp/decoded
+cmp /tmp/decoded /app/www/assets/index-Ab12_-34.js
+
+# A missing sidecar remains a valid original response; gzip-only clients still use gzip.
+fetch --header='Accept-Encoding: br' http://127.0.0.1:8080/assets/plain-Ab12_-34.js
+if grep -q 'Content-Encoding:' /tmp/headers; then exit 1; fi
+cmp /tmp/body /app/www/assets/plain-Ab12_-34.js
+fetch --header='Accept-Encoding: gzip' http://127.0.0.1:8080/assets/plain-Ab12_-34.js
+grep -q 'Content-Encoding: gzip' /tmp/headers
+
+for asset_path in /assets/missing-Ab12_-34.js /staff/assets/missing-Ab12_-34.js /assets/missing.js /staff/assets/missing.css /assets/orphan-Ab12_-34.js; do
+    fetch --header='Accept-Encoding: gzip, br' "http://127.0.0.1:8080$asset_path"
+    grep -q 'HTTP/1.1 404' /tmp/headers
+    if grep -q 'immutable' /tmp/headers || grep -q 'entry' /tmp/body; then
+        exit 1
+    fi
+done
+
+for asset_path in /assets/runtime.js /assets/fonts/public-sans.woff2 /assets/test-12345678Xjs; do
+    fetch "http://127.0.0.1:8080$asset_path"
+    grep -q 'HTTP/1.1 200' /tmp/headers
+    grep -q 'Cache-Control: no-cache' /tmp/headers
+    if grep -q 'immutable' /tmp/headers; then exit 1; fi
+done
+
+for route_path in / /form/example /staff /staff/processes /sbom/manifest.json; do
+    fetch "http://127.0.0.1:8080$route_path"
+    grep -q 'HTTP/1.1 200' /tmp/headers
+    grep -q 'Cache-Control: no-store, no-cache, must-revalidate' /tmp/headers
+    if grep -q 'immutable' /tmp/headers; then exit 1; fi
+done
+
+printf 'Nginx compression, cache and missing-asset checks passed.\n'

--- a/development/FRONTEND_ASSETS.md
+++ b/development/FRONTEND_ASSETS.md
@@ -1,0 +1,155 @@
+# Frontend assets
+
+This document describes how frontend files are built, loaded and served. The
+executable configuration is authoritative: [package.json](../app/package.json),
+the [customer](../app/vite.config.customer.js) and
+[staff](../app/vite.config.staff.js) Vite configurations,
+[Containerfile](../Containerfile) and [Nginx configuration](../container/nginx.conf).
+Keep their paths, output naming and delivery rules aligned when changing them.
+
+## Build outputs and asset ownership
+
+The frontend has separate customer and staff builds. Both use `app/index.html`;
+`VITE_APP_MODE` selects the corresponding TypeScript entry point.
+
+| Build | Output directory | Container directory | URL base |
+| --- | --- | --- | --- |
+| Customer | `app/build/customer/` | `/app/www/` | `/` |
+| Staff | `app/build/staff/` | `/app/www/staff/` | `/staff/` |
+
+Import assets from application source when Vite should process them, rewrite
+references and generate content-hashed filenames. Files in `app/public/` are
+copied into each build without content hashing. Use public files for resources
+that need stable URLs, and do not assume that a file is versioned simply because
+it resides under `assets/`. Avoid hand-written URLs to generated chunks; let Vite
+resolve imports and worker references for the appropriate shell base.
+
+The backend supplies runtime configuration through
+`/api/public/system/app-config.js`, which the HTML loads before the frontend
+entry. It is not a generated Vite asset. The container also publishes one SBOM
+bundle under `/sbom/`, independently of the two frontend builds.
+
+## Loading optional functionality
+
+Use dynamic imports at the point where optional functionality is needed. Keep
+runtime imports behind that boundary; use type-only imports in shared interfaces
+so an optional dependency is not pulled into the initial JavaScript graph.
+Moving code into a chunk defers its download and execution; it does not remove
+its size from the complete application.
+
+Share concurrent initialization and reuse successful loads. A failed download
+must allow a later attempt. Keep errors local to the affected surface and preserve
+other user inputs. Discard asynchronous results when their input changes or the
+surface closes. Do not automatically reload a page to recover a missing chunk.
+
+Use the shared `withAsyncWrapper` utility for minimum loading durations. Apply
+visible results after it resolves, not in its `after` callback, which runs before
+the minimum duration has elapsed. Rejected operations bypass the wrapper's delay;
+when an error transition also needs the minimum duration, settle the operation
+inside `main` and handle its outcome after the wrapper resolves. Keep presentation
+delays out of repeated calculations on an already initialized runtime.
+
+Monaco and ELK have additional initialization requirements:
+
+- Monaco's local loader configuration and language workers belong to its deferred
+  runtime. Configuration must run before an editor mounts. Retain editor values,
+  read-only state and model behavior through loading and rerendering.
+  Vite remembers failed stylesheet preloads; retrying the import can skip those
+  styles. The loader retains such a failure until a manual page reload to avoid
+  mounting an unstyled editor. Review this guard when updating Vite.
+- Process flows and department diagrams retain separate ELK instances and layout
+  options. Runtime download retries must restore the diagram's measurement and
+  viewport sequence. The team diagram uses its own layout without ELK.
+
+## HTTP delivery
+
+Nginx serves static files and falls back to the corresponding HTML entry for SPA
+routes. Requests for missing assets must return 404, rather than HTML that the
+browser could mistake for JavaScript or CSS.
+
+Cache policy depends on whether a URL changes when its content changes:
+
+| Resource | Policy |
+| --- | --- |
+| Content-hashed JS and CSS under either shell's `assets/` directory | Long-lived, immutable cache |
+| Other files under those asset directories | Revalidate before reuse |
+| HTML entries and the SBOM manifest | No-store |
+
+The immutable rule matches Vite's eight-character content hash. Review the rule
+when changing output naming or adding file types; do not extend it to arbitrary
+public files or runtime configuration. A cached hashed URL must always refer to
+the same content. The Nginx configuration defines the exact lifetimes and headers.
+
+The npm build commands run `scripts/compress-assets.mjs` as a postbuild step.
+It creates Brotli sidecars (`.br`) for content-hashed JavaScript and CSS, including
+workers, using Node's built-in compressor. Quality 11 runs at build time with
+bounded concurrency; requests do not perform Brotli compression. Originals remain
+available, and sidecars are omitted if compression would increase the file size.
+Keep the script's filename rule aligned with the Nginx immutable rule. Invoke the
+npm build commands when preparing deployments: running `vite build` directly
+does not run npm's postbuild step.
+
+The container installs Alpine's `nginx-mod-http-brotli` alongside Nginx. Its static
+module serves the sidecar at the original asset URL when the client accepts
+`br`. The response retains the original MIME type and includes `Content-Encoding:
+br` and `Vary: Accept-Encoding`. Gzip-only clients use the configured gzip
+compression; clients without encoding support receive the original. A missing
+sidecar still permits an uncompressed response. Deploy originals and sidecars
+together, and do not rewrite application imports to point to `.br` URLs.
+
+Verify content negotiation, MIME types and cache headers through the deployed
+reverse proxy, not only at the container boundary. Proxy cache keys must respect
+`Vary: Accept-Encoding` so compressed bytes never reach an incompatible client.
+
+## Deployments and open tabs
+
+Deploy HTML and its referenced assets consistently. Long-lived tabs can still
+request chunks from an older build after a release. Browser caching cannot supply
+an old chunk that the browser has never downloaded.
+
+The application container contains the current build only. Deployments that must
+support old tabs without reloading need to retain and serve previous hashed
+assets for a suitable transition period, including during rolling updates. A
+retry cannot recover a file that is no longer available. If recovery requires a
+manual reload, users must have an opportunity to save their inputs first.
+
+## Verification and diagnosis
+
+Run frontend checks from `app/`:
+
+```sh
+npm test
+npm run test:assets
+npm run typecheck
+npm run build:staff
+npm run build:customer
+```
+
+Check both shells when changing shared imports, asset paths or build settings.
+Measure initial JavaScript using the HTML entry and its recursive static imports;
+report dynamic chunks, workers and CSS separately. Distinguish minified size,
+compressed transfer size and browser execution time. Keep release-specific size
+comparisons in change descriptions or performance reports.
+
+Run the finite Nginx HTTP regression check from the repository root:
+
+```sh
+docker build -f container/Containerfile.nginx-test -t prosuna-nginx-test .
+docker run --rm --network none prosuna-nginx-test
+```
+
+This script creates fixtures and starts Nginx only inside the disposable
+container. The image uses Alpine's Nginx and Brotli packages, matching the
+production Containerfile. It checks Brotli/gzip negotiation, lossless content,
+MIME types, cache headers, missing sidecars and assets, SPA routes and SBOM
+headers. Do not run the script on a persistent application host. Keep the test
+image's Alpine release aligned with the production runtime. CI runs the build
+script tests and these HTTP checks with the frontend tests.
+
+Use production builds to inspect chunk requests and delivery headers; a Vite
+development server does not reproduce production bundling or Nginx caching.
+Check cold and warm caches, throttled or failed downloads, retries, navigation
+while loading, and tabs left open across a deployment. Verify that optional
+runtimes load when needed and that worker URLs stay local to the application.
+For editor or diagram changes, also check input preservation, read-only behavior,
+selection and viewport restoration on the supported shell viewports.


### PR DESCRIPTION
Reduce initial frontend JavaScript transfer by deferring optional runtimes, improving gzip compression, and serving precompressed Brotli assets. Initial transfer is approximately **61% smaller for Customer and 62% smaller for Staff with Brotli**, or **50% smaller with gzip**.

| Initial JavaScript transfer | Customer | Staff |
|---|---:|---:|
| Baseline: eager loading, gzip 1 | 2.983 MB | 4.244 MB |
| Deferred loading, gzip 1 | 1.771 MB | 2.518 MB |
| Deferred loading, gzip 6 | 1.500 MB | 2.134 MB |
| Deferred loading, Brotli 11 | **1.174 MB** | **1.618 MB** |
| Overall reduction with Brotli | **60.7%** | **61.9%** |

Individual contributions:

- **Monaco:** Defer approximately 3.94 MB minified / 0.99 MB gzip per shell until an editor mounts. Preserve local workers, editor values, read-only behavior and type hints.
- **ELK:** Defer approximately 1.43 MB minified / 0.436 MB gzip from Staff until diagram layout is needed. Preserve existing algorithms and reuse initialized instances.
- **gzip:** Level 6 reduces transfer by another approximately 15% after deferred loading.
- **Brotli:** Build-time quality 11 compression saves another 21.7% for Customer and 24.2% for Staff compared with gzip 6.
- **Caching:** Immutable caching lets browsers reuse unchanged versioned assets without revalidation. These savings are additional and are not included in the table.

Loading states use a minimum duration. Recovery preserves unsaved inputs, supports safe retries and discards obsolete layout results. Missing assets return 404 instead of SPA HTML. No recovery path automatically reloads the page.

Validation includes two compression tests, type checking, both production builds, and Nginx HTTP tests covering negotiation, cache validators, HEAD requests and missing assets. Compression and HTTP checks are included in CI.

Measurements compare production builds against the previous version and cover the initial static JavaScript graph. CSS, workers and later feature downloads are excluded; these are payload measurements, not browser timings.

Brotli adds build-time work and approximately 8.2 MB of sidecars, with no request-time Brotli compression. Browser and deployed-proxy checks remain manual. Supporting old tabs across deployments still requires retaining previous hashed assets.